### PR TITLE
Implement HTTP transport layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/0x6d61/sqleech
 
 go 1.25.0
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/spf13/cobra v1.10.2
+	golang.org/x/time v0.14.0
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,6 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
+golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -1,0 +1,272 @@
+package transport
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// Client is the interface for the HTTP transport layer. All injection
+// testing flows go through this interface.
+type Client interface {
+	// Do sends an HTTP request and returns the response.
+	Do(ctx context.Context, req *Request) (*Response, error)
+
+	// SetProxy configures an HTTP/SOCKS5 proxy for all subsequent requests.
+	SetProxy(proxyURL string) error
+
+	// SetRateLimit sets the maximum requests per second.
+	SetRateLimit(rps float64)
+
+	// Stats returns transport statistics.
+	Stats() *TransportStats
+}
+
+// TransportStats holds aggregate statistics for the transport client.
+type TransportStats struct {
+	TotalRequests int64
+	TotalDuration time.Duration
+	AvgDuration   time.Duration
+}
+
+// ClientOptions holds configuration for creating a new DefaultClient.
+type ClientOptions struct {
+	// Timeout is the default timeout for all requests.
+	Timeout time.Duration
+
+	// ProxyURL is the proxy URL (HTTP or SOCKS5).
+	ProxyURL string
+
+	// FollowRedirects controls whether redirects are followed.
+	FollowRedirects bool
+
+	// InsecureSkipVerify disables TLS certificate verification.
+	InsecureSkipVerify bool
+
+	// RandomUserAgent enables random User-Agent header selection.
+	RandomUserAgent bool
+
+	// MaxRPS is the maximum requests per second (0 = unlimited).
+	MaxRPS float64
+}
+
+// DefaultClient is the default implementation of the Client interface,
+// backed by net/http.
+type DefaultClient struct {
+	httpClient      *http.Client
+	opts            ClientOptions
+	limiter         *rate.Limiter
+	mu              sync.RWMutex
+	totalRequests   int64
+	totalDurationNs int64
+}
+
+// NewClient creates a new DefaultClient with the given options.
+func NewClient(opts ClientOptions) (*DefaultClient, error) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: opts.InsecureSkipVerify,
+		},
+		// Enable HTTP/2 by default via ForceAttemptHTTP2
+		ForceAttemptHTTP2: true,
+	}
+
+	// Configure proxy if provided.
+	if opts.ProxyURL != "" {
+		proxyURL, err := url.Parse(opts.ProxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy URL: %w", err)
+		}
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   opts.Timeout,
+	}
+
+	// Configure redirect policy.
+	if !opts.FollowRedirects {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
+	dc := &DefaultClient{
+		httpClient: client,
+		opts:       opts,
+	}
+
+	// Configure rate limiter if specified.
+	if opts.MaxRPS > 0 {
+		dc.limiter = rate.NewLimiter(rate.Limit(opts.MaxRPS), 1)
+	}
+
+	return dc, nil
+}
+
+// Do sends an HTTP request and returns the response. It applies rate
+// limiting, timing measurement, custom headers, cookies, and optional
+// per-request overrides.
+func (c *DefaultClient) Do(ctx context.Context, req *Request) (*Response, error) {
+	// Rate limiting
+	if c.limiter != nil {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter: %w", err)
+		}
+	}
+
+	// Build the stdlib HTTP request.
+	var bodyReader io.Reader
+	if req.Body != "" {
+		bodyReader = strings.NewReader(req.Body)
+	}
+
+	method := req.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, req.URL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Set Content-Type if provided.
+	if req.ContentType != "" {
+		httpReq.Header.Set("Content-Type", req.ContentType)
+	}
+
+	// Set custom headers.
+	for k, v := range req.Headers {
+		httpReq.Header.Set(k, v)
+	}
+
+	// Set cookies.
+	for name, value := range req.Cookies {
+		httpReq.AddCookie(&http.Cookie{Name: name, Value: value})
+	}
+
+	// Set random User-Agent if enabled and no explicit User-Agent header.
+	if c.opts.RandomUserAgent && httpReq.Header.Get("User-Agent") == "" {
+		httpReq.Header.Set("User-Agent", RandomUserAgent())
+	}
+
+	// Determine which HTTP client to use. If we need per-request overrides
+	// for redirect policy or timeout, we create a shallow copy.
+	httpClient := c.httpClient
+	needCustomClient := false
+
+	if req.FollowRedirects != nil {
+		needCustomClient = true
+	}
+	if req.Timeout > 0 {
+		needCustomClient = true
+	}
+
+	if needCustomClient {
+		cc := *c.httpClient
+		if req.Timeout > 0 {
+			cc.Timeout = req.Timeout
+		}
+		if req.FollowRedirects != nil {
+			if *req.FollowRedirects {
+				cc.CheckRedirect = nil // follow redirects (default behavior)
+			} else {
+				cc.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse
+				}
+			}
+		}
+		httpClient = &cc
+	}
+
+	// Perform the request with timing.
+	start := time.Now()
+	httpResp, err := httpClient.Do(httpReq)
+	duration := time.Since(start)
+
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	// Read the response body.
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	// Determine protocol version string.
+	protocol := fmt.Sprintf("HTTP/%d.%d", httpResp.ProtoMajor, httpResp.ProtoMinor)
+
+	resp := &Response{
+		StatusCode:    httpResp.StatusCode,
+		Headers:       httpResp.Header,
+		Body:          body,
+		ContentLength: httpResp.ContentLength,
+		Duration:      duration,
+		URL:           httpResp.Request.URL.String(),
+		Protocol:      protocol,
+	}
+
+	// Update statistics.
+	c.mu.Lock()
+	c.totalRequests++
+	c.totalDurationNs += duration.Nanoseconds()
+	c.mu.Unlock()
+
+	return resp, nil
+}
+
+// SetProxy configures an HTTP or SOCKS5 proxy for subsequent requests.
+func (c *DefaultClient) SetProxy(proxyURL string) error {
+	parsedURL, err := url.Parse(proxyURL)
+	if err != nil {
+		return fmt.Errorf("invalid proxy URL: %w", err)
+	}
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return fmt.Errorf("invalid proxy URL: missing scheme or host")
+	}
+
+	transport, ok := c.httpClient.Transport.(*http.Transport)
+	if !ok {
+		return fmt.Errorf("cannot set proxy: transport is not *http.Transport")
+	}
+
+	transport.Proxy = http.ProxyURL(parsedURL)
+	return nil
+}
+
+// SetRateLimit sets the maximum number of requests per second.
+// A value of 0 or less disables rate limiting.
+func (c *DefaultClient) SetRateLimit(rps float64) {
+	if rps <= 0 {
+		c.limiter = nil
+		return
+	}
+	c.limiter = rate.NewLimiter(rate.Limit(rps), 1)
+}
+
+// Stats returns aggregate transport statistics.
+func (c *DefaultClient) Stats() *TransportStats {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	stats := &TransportStats{
+		TotalRequests: c.totalRequests,
+		TotalDuration: time.Duration(c.totalDurationNs),
+	}
+	if c.totalRequests > 0 {
+		stats.AvgDuration = time.Duration(c.totalDurationNs / c.totalRequests)
+	}
+	return stats
+}

--- a/internal/transport/client_test.go
+++ b/internal/transport/client_test.go
@@ -1,0 +1,668 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Helper: create a default test client
+// ---------------------------------------------------------------------------
+
+func newTestClient(t *testing.T) *DefaultClient {
+	t.Helper()
+	c, err := NewClient(ClientOptions{
+		Timeout:         5 * time.Second,
+		FollowRedirects: true,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// Basic GET
+// ---------------------------------------------------------------------------
+
+func TestBasicGET(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "hello world")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	resp, err := c.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL + "/test",
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if resp.BodyString() != "hello world" {
+		t.Errorf("Body = %q, want %q", resp.BodyString(), "hello world")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST with body
+// ---------------------------------------------------------------------------
+
+func TestPOSTWithBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	resp, err := c.Do(context.Background(), &Request{
+		Method:      "POST",
+		URL:         srv.URL + "/submit",
+		Body:        `{"key":"value"}`,
+		ContentType: "application/json",
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if resp.BodyString() != `{"key":"value"}` {
+		t.Errorf("Body = %q", resp.BodyString())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Custom headers and cookies
+// ---------------------------------------------------------------------------
+
+func TestCustomHeadersAndCookies(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check custom header
+		if got := r.Header.Get("X-Custom"); got != "test-value" {
+			t.Errorf("X-Custom header = %q, want %q", got, "test-value")
+		}
+		// Check cookie
+		cookie, err := r.Cookie("session")
+		if err != nil {
+			t.Errorf("cookie 'session' not found: %v", err)
+		} else if cookie.Value != "abc123" {
+			t.Errorf("session cookie = %q, want %q", cookie.Value, "abc123")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	_, err := c.Do(context.Background(), &Request{
+		Method:  "GET",
+		URL:     srv.URL,
+		Headers: map[string]string{"X-Custom": "test-value"},
+		Cookies: map[string]string{"session": "abc123"},
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Response timing measurement
+// ---------------------------------------------------------------------------
+
+func TestResponseTimingMeasurement(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	resp, err := c.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if resp.Duration <= 0 {
+		t.Errorf("Duration = %v, want > 0", resp.Duration)
+	}
+	if resp.Duration < 40*time.Millisecond {
+		t.Errorf("Duration = %v, expected at least ~50ms", resp.Duration)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Redirect following
+// ---------------------------------------------------------------------------
+
+func TestRedirectFollowing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "/final", http.StatusFound)
+			return
+		}
+		fmt.Fprint(w, "final page")
+	}))
+	defer srv.Close()
+
+	// Follow redirects
+	c, _ := NewClient(ClientOptions{
+		Timeout:         5 * time.Second,
+		FollowRedirects: true,
+	})
+	resp, err := c.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL + "/redirect",
+	})
+	if err != nil {
+		t.Fatalf("Do (follow): %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("follow: StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if resp.BodyString() != "final page" {
+		t.Errorf("follow: Body = %q, want %q", resp.BodyString(), "final page")
+	}
+	if !strings.HasSuffix(resp.URL, "/final") {
+		t.Errorf("follow: URL = %q, want suffix /final", resp.URL)
+	}
+}
+
+func TestRedirectNotFollowing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "/final", http.StatusFound)
+			return
+		}
+		fmt.Fprint(w, "final page")
+	}))
+	defer srv.Close()
+
+	// Do NOT follow redirects
+	c, _ := NewClient(ClientOptions{
+		Timeout:         5 * time.Second,
+		FollowRedirects: false,
+	})
+	resp, err := c.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL + "/redirect",
+	})
+	if err != nil {
+		t.Fatalf("Do (no-follow): %v", err)
+	}
+	if resp.StatusCode != 302 {
+		t.Errorf("no-follow: StatusCode = %d, want 302", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-request redirect override
+// ---------------------------------------------------------------------------
+
+func TestPerRequestRedirectOverride(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "/final", http.StatusFound)
+			return
+		}
+		fmt.Fprint(w, "final page")
+	}))
+	defer srv.Close()
+
+	// Client follows redirects, but per-request says no.
+	c, _ := NewClient(ClientOptions{
+		Timeout:         5 * time.Second,
+		FollowRedirects: true,
+	})
+	noFollow := false
+	resp, err := c.Do(context.Background(), &Request{
+		Method:          "GET",
+		URL:             srv.URL + "/redirect",
+		FollowRedirects: &noFollow,
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if resp.StatusCode != 302 {
+		t.Errorf("StatusCode = %d, want 302", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy configuration (test setting, not actual proxy)
+// ---------------------------------------------------------------------------
+
+func TestSetProxy(t *testing.T) {
+	c := newTestClient(t)
+	err := c.SetProxy("http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("SetProxy: %v", err)
+	}
+	// Setting an invalid URL should error.
+	err = c.SetProxy("://bad-url")
+	if err == nil {
+		t.Error("SetProxy with invalid URL should return error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Status code handling
+// ---------------------------------------------------------------------------
+
+func TestStatusCodeHandling(t *testing.T) {
+	codes := []int{200, 302, 403, 404, 500}
+	for _, code := range codes {
+		code := code
+		t.Run(fmt.Sprintf("status_%d", code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			c, _ := NewClient(ClientOptions{
+				Timeout:         5 * time.Second,
+				FollowRedirects: false, // don't follow 302
+			})
+			resp, err := c.Do(context.Background(), &Request{
+				Method: "GET",
+				URL:    srv.URL,
+			})
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			if resp.StatusCode != code {
+				t.Errorf("StatusCode = %d, want %d", resp.StatusCode, code)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Timeout handling
+// ---------------------------------------------------------------------------
+
+func TestTimeoutHandling(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(ClientOptions{
+		Timeout: 100 * time.Millisecond,
+	})
+	_, err := c.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL,
+	})
+	if err == nil {
+		t.Error("expected timeout error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-request timeout override
+// ---------------------------------------------------------------------------
+
+func TestPerRequestTimeoutOverride(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Client has 5s timeout, but per-request overrides to 100ms.
+	c, _ := NewClient(ClientOptions{
+		Timeout: 5 * time.Second,
+	})
+	_, err := c.Do(context.Background(), &Request{
+		Method:  "GET",
+		URL:     srv.URL,
+		Timeout: 100 * time.Millisecond,
+	})
+	if err == nil {
+		t.Error("expected timeout error from per-request override, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stats tracking
+// ---------------------------------------------------------------------------
+
+func TestStatsTracking(t *testing.T) {
+	var reqCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	for i := 0; i < 5; i++ {
+		_, err := c.Do(context.Background(), &Request{
+			Method: "GET",
+			URL:    srv.URL,
+		})
+		if err != nil {
+			t.Fatalf("Do #%d: %v", i, err)
+		}
+	}
+
+	stats := c.Stats()
+	if stats.TotalRequests != 5 {
+		t.Errorf("TotalRequests = %d, want 5", stats.TotalRequests)
+	}
+	if stats.AvgDuration <= 0 {
+		t.Errorf("AvgDuration = %v, want > 0", stats.AvgDuration)
+	}
+	if stats.TotalDuration <= 0 {
+		t.Errorf("TotalDuration = %v, want > 0", stats.TotalDuration)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TLS InsecureSkipVerify option
+// ---------------------------------------------------------------------------
+
+func TestTLSInsecureSkipVerifyOption(t *testing.T) {
+	// Just verify that the option can be set without error.
+	c, err := NewClient(ClientOptions{
+		Timeout:            5 * time.Second,
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatalf("NewClient with InsecureSkipVerify: %v", err)
+	}
+	if c == nil {
+		t.Fatal("NewClient returned nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TLS InsecureSkipVerify actually works with self-signed cert
+// ---------------------------------------------------------------------------
+
+func TestTLSInsecureSkipVerifyWithHTTPS(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "secure")
+	}))
+	defer srv.Close()
+
+	// Without InsecureSkipVerify, connection to self-signed cert should fail
+	cStrict, _ := NewClient(ClientOptions{
+		Timeout:            5 * time.Second,
+		InsecureSkipVerify: false,
+	})
+	_, err := cStrict.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL,
+	})
+	if err == nil {
+		t.Error("expected TLS error with strict verification, got nil")
+	}
+
+	// With InsecureSkipVerify, it should succeed
+	cInsecure, _ := NewClient(ClientOptions{
+		Timeout:            5 * time.Second,
+		InsecureSkipVerify: true,
+	})
+	resp, err := cInsecure.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Do with InsecureSkipVerify: %v", err)
+	}
+	if resp.BodyString() != "secure" {
+		t.Errorf("Body = %q, want %q", resp.BodyString(), "secure")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Request Clone
+// ---------------------------------------------------------------------------
+
+func TestRequestClone(t *testing.T) {
+	orig := &Request{
+		Method:      "POST",
+		URL:         "http://example.com/test",
+		Headers:     map[string]string{"X-Foo": "bar"},
+		Body:        "original body",
+		ContentType: "text/plain",
+		Cookies:     map[string]string{"session": "abc"},
+		Timeout:     3 * time.Second,
+	}
+
+	clone := orig.Clone()
+
+	// Verify values match
+	if clone.Method != orig.Method {
+		t.Errorf("clone.Method = %q, want %q", clone.Method, orig.Method)
+	}
+	if clone.URL != orig.URL {
+		t.Errorf("clone.URL = %q, want %q", clone.URL, orig.URL)
+	}
+	if clone.Body != orig.Body {
+		t.Errorf("clone.Body = %q, want %q", clone.Body, orig.Body)
+	}
+	if clone.ContentType != orig.ContentType {
+		t.Errorf("clone.ContentType = %q, want %q", clone.ContentType, orig.ContentType)
+	}
+	if clone.Timeout != orig.Timeout {
+		t.Errorf("clone.Timeout = %v, want %v", clone.Timeout, orig.Timeout)
+	}
+
+	// Verify deep copy: mutating clone's maps should not affect original
+	clone.Headers["X-Foo"] = "changed"
+	if orig.Headers["X-Foo"] != "bar" {
+		t.Error("modifying clone.Headers affected original")
+	}
+
+	clone.Cookies["session"] = "changed"
+	if orig.Cookies["session"] != "abc" {
+		t.Error("modifying clone.Cookies affected original")
+	}
+}
+
+func TestRequestCloneNilMaps(t *testing.T) {
+	orig := &Request{
+		Method: "GET",
+		URL:    "http://example.com",
+	}
+	clone := orig.Clone()
+	if clone.Headers != nil {
+		t.Error("clone.Headers should be nil when original is nil")
+	}
+	if clone.Cookies != nil {
+		t.Error("clone.Cookies should be nil when original is nil")
+	}
+}
+
+func TestRequestCloneFollowRedirects(t *testing.T) {
+	val := true
+	orig := &Request{
+		Method:          "GET",
+		URL:             "http://example.com",
+		FollowRedirects: &val,
+	}
+	clone := orig.Clone()
+	if clone.FollowRedirects == nil {
+		t.Fatal("clone.FollowRedirects should not be nil")
+	}
+	if *clone.FollowRedirects != true {
+		t.Error("clone.FollowRedirects value mismatch")
+	}
+	// Verify deep copy of the pointer
+	*clone.FollowRedirects = false
+	if *orig.FollowRedirects != true {
+		t.Error("modifying clone.FollowRedirects affected original")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Random User-Agent header
+// ---------------------------------------------------------------------------
+
+func TestRandomUserAgentHeader(t *testing.T) {
+	var receivedUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(ClientOptions{
+		Timeout:        5 * time.Second,
+		RandomUserAgent: true,
+	})
+	_, err := c.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if receivedUA == "" {
+		t.Error("User-Agent header was empty")
+	}
+	// It should not be Go's default User-Agent
+	if strings.HasPrefix(receivedUA, "Go-http-client") {
+		t.Errorf("User-Agent = %q, should be randomized", receivedUA)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+
+func TestSetRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	c.SetRateLimit(10) // 10 RPS
+
+	start := time.Now()
+	for i := 0; i < 5; i++ {
+		_, err := c.Do(context.Background(), &Request{
+			Method: "GET",
+			URL:    srv.URL,
+		})
+		if err != nil {
+			t.Fatalf("Do #%d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+
+	// At 10 RPS, 5 requests should take at least ~400ms (first is immediate, then 4 waits of ~100ms).
+	// We use a conservative threshold.
+	if elapsed < 300*time.Millisecond {
+		t.Errorf("5 requests at 10 RPS took %v, expected at least ~400ms", elapsed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Context cancellation
+// ---------------------------------------------------------------------------
+
+func TestContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := c.Do(ctx, &Request{
+		Method: "GET",
+		URL:    srv.URL,
+	})
+	if err == nil {
+		t.Error("expected context cancellation error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Client interface satisfaction
+// ---------------------------------------------------------------------------
+
+func TestClientInterfaceSatisfaction(t *testing.T) {
+	var _ Client = (*DefaultClient)(nil)
+}
+
+// ---------------------------------------------------------------------------
+// Content-Type header set for POST
+// ---------------------------------------------------------------------------
+
+func TestContentTypeHeader(t *testing.T) {
+	var receivedCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCT = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	_, err := c.Do(context.Background(), &Request{
+		Method:      "POST",
+		URL:         srv.URL,
+		Body:        "data",
+		ContentType: "application/x-www-form-urlencoded",
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if receivedCT != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want %q", receivedCT, "application/x-www-form-urlencoded")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Response headers
+// ---------------------------------------------------------------------------
+
+func TestResponseHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Server", "sqleech-test")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	resp, err := c.Do(context.Background(), &Request{
+		Method: "GET",
+		URL:    srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if got := resp.Headers.Get("X-Server"); got != "sqleech-test" {
+		t.Errorf("X-Server header = %q, want %q", got, "sqleech-test")
+	}
+}

--- a/internal/transport/request.go
+++ b/internal/transport/request.go
@@ -1,0 +1,70 @@
+// Package transport provides the HTTP transport abstraction layer
+// used by all injection testing flows.
+package transport
+
+import "time"
+
+// Request represents an HTTP request to be sent by the transport client.
+type Request struct {
+	// Method is the HTTP method (GET, POST, PUT, etc.).
+	Method string
+
+	// URL is the target URL.
+	URL string
+
+	// Headers contains custom HTTP headers to include.
+	Headers map[string]string
+
+	// Body is the request body content.
+	Body string
+
+	// ContentType is the Content-Type header value.
+	ContentType string
+
+	// Cookies contains cookies to include in the request.
+	Cookies map[string]string
+
+	// FollowRedirects overrides the client-level redirect setting
+	// for this specific request. nil means use the client default.
+	FollowRedirects *bool
+
+	// Timeout overrides the client-level timeout for this specific
+	// request. Zero means use the client default.
+	Timeout time.Duration
+}
+
+// Clone returns a deep copy of the Request.
+func (r *Request) Clone() *Request {
+	if r == nil {
+		return nil
+	}
+
+	clone := &Request{
+		Method:      r.Method,
+		URL:         r.URL,
+		Body:        r.Body,
+		ContentType: r.ContentType,
+		Timeout:     r.Timeout,
+	}
+
+	if r.Headers != nil {
+		clone.Headers = make(map[string]string, len(r.Headers))
+		for k, v := range r.Headers {
+			clone.Headers[k] = v
+		}
+	}
+
+	if r.Cookies != nil {
+		clone.Cookies = make(map[string]string, len(r.Cookies))
+		for k, v := range r.Cookies {
+			clone.Cookies[k] = v
+		}
+	}
+
+	if r.FollowRedirects != nil {
+		val := *r.FollowRedirects
+		clone.FollowRedirects = &val
+	}
+
+	return clone
+}

--- a/internal/transport/response.go
+++ b/internal/transport/response.go
@@ -1,0 +1,35 @@
+package transport
+
+import (
+	"net/http"
+	"time"
+)
+
+// Response represents an HTTP response received from the transport client.
+type Response struct {
+	// StatusCode is the HTTP status code.
+	StatusCode int
+
+	// Headers contains the response headers.
+	Headers http.Header
+
+	// Body is the raw response body.
+	Body []byte
+
+	// ContentLength is the content length from the response header.
+	ContentLength int64
+
+	// Duration is the precise round-trip time for the request.
+	Duration time.Duration
+
+	// URL is the final URL after any redirects.
+	URL string
+
+	// Protocol is the protocol version (e.g., "HTTP/1.1", "HTTP/2.0").
+	Protocol string
+}
+
+// BodyString returns the response body as a string.
+func (r *Response) BodyString() string {
+	return string(r.Body)
+}

--- a/internal/transport/useragent.go
+++ b/internal/transport/useragent.go
@@ -1,0 +1,58 @@
+package transport
+
+import "math/rand/v2"
+
+// userAgents is a list of realistic browser User-Agent strings used for
+// randomization. Keeping a diverse set across Chrome, Firefox, Safari, and
+// Edge on various operating systems helps avoid trivial fingerprinting.
+var userAgents = []string{
+	// Chrome on Windows
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+
+	// Chrome on macOS
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+
+	// Chrome on Linux
+	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+
+	// Firefox on Windows
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0",
+
+	// Firefox on macOS
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0",
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:124.0) Gecko/20100101 Firefox/124.0",
+
+	// Firefox on Linux
+	"Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0",
+	"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0",
+
+	// Safari on macOS
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3 Safari/605.1.15",
+
+	// Edge on Windows
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 Edg/123.0.0.0",
+
+	// Chrome on Android
+	"Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36",
+
+	// Safari on iOS
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+
+	// Edge on macOS
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0",
+}
+
+// RandomUserAgent returns a randomly selected User-Agent string from the
+// built-in list.
+func RandomUserAgent() string {
+	return userAgents[rand.IntN(len(userAgents))]
+}

--- a/internal/transport/useragent_test.go
+++ b/internal/transport/useragent_test.go
@@ -1,0 +1,52 @@
+package transport
+
+import (
+	"testing"
+)
+
+func TestRandomUserAgentNotEmpty(t *testing.T) {
+	ua := RandomUserAgent()
+	if ua == "" {
+		t.Error("RandomUserAgent() returned empty string")
+	}
+}
+
+func TestRandomUserAgentReturnsFromList(t *testing.T) {
+	ua := RandomUserAgent()
+	found := false
+	for _, agent := range userAgents {
+		if ua == agent {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("RandomUserAgent() returned %q which is not in the userAgents list", ua)
+	}
+}
+
+func TestUserAgentsListHasMinimumEntries(t *testing.T) {
+	if len(userAgents) < 20 {
+		t.Errorf("userAgents list has %d entries, want at least 20", len(userAgents))
+	}
+}
+
+func TestRandomUserAgentVariation(t *testing.T) {
+	// Call RandomUserAgent many times and check that we get at least 2 different values.
+	// With 20+ entries, getting the same one 100 times in a row is astronomically unlikely.
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		seen[RandomUserAgent()] = true
+	}
+	if len(seen) < 2 {
+		t.Errorf("RandomUserAgent() returned only %d unique value(s) in 100 calls; expected variation", len(seen))
+	}
+}
+
+func TestUserAgentsArePlausible(t *testing.T) {
+	for i, ua := range userAgents {
+		if len(ua) < 10 {
+			t.Errorf("userAgents[%d] = %q is suspiciously short", i, ua)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- HTTP transport abstraction with `Client` interface for all injection testing
- HTTP/1.1 + HTTP/2, proxy (HTTP/SOCKS5), rate limiting, response timing
- 28 tests covering all functionality

## Test plan
- [x] `go test ./internal/transport/...` passes
- [x] Request/Response types with clone support
- [x] Redirect control, timeout, TLS skip-verify tested

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)